### PR TITLE
Allow JSON booleans for BOOLEAN args

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
 == 2.1 ==
  * Migrate CH tables from geni-portal to geni-ch (#103).
  * Support lists of project_ids in option for lookup_project_attributes (#391).
+ * Allow JSON booleans for boolean type arguments to API calls (#394)
 
 == 2.0 ==
  * Add procedure to add new aggregate (#383).

--- a/plugins/chrm/ArgumentCheck.py
+++ b/plugins/chrm/ArgumentCheck.py
@@ -220,7 +220,8 @@ class FieldsArgumentCheck(ArgumentCheck):
         elif field_type == "KEY":
             pass # *** No standard format
         elif field_type == "BOOLEAN":
-            properly_formed = value.lower() in ['t', 'f', 'true', 'false']
+            properly_formed = (type(value) is bool or
+                               value.lower() in ['t', 'f', 'true', 'false'])
         elif field_type == "CREDENTIALS":
             try:
                 Credential(string=value)


### PR DESCRIPTION
Arguments denoted as BOOLEAN in the API spec are parsed as strings in
the argument checking. Make the BOOLEAN argument type more flexible by
allowing bool objects in addition to strings. Fixes #394,
SLICE_EXPIRED caused a server error when a JSON boolean was passed.