### PR TITLE
Return most recent slice from SA.lookup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
 == 2.1 ==
  * Migrate CH tables from geni-portal to geni-ch (#103).
  * Support lists of project_ids in option for lookup_project_attributes (#391).
+ * Return most recent slice from SA.lookup and SA.lookup_slices (#393)
  * Allow JSON booleans for boolean type arguments to API calls (#394)
 
 == 2.0 ==

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -226,6 +226,10 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         q = add_filters(q, match_criteria, self.db.SLICE_TABLE, SA.slice_field_mapping, session)
 
+        # Order by expiration to get the active one or the most recently
+        # expired instance and to provide deterministic behavior
+        q = q.order_by(self.db.SLICE_TABLE.c.expiration)
+
         rows = q.all()
 
         # in python 2.7, could do dictionary comprehension !!!!!!!!


### PR DESCRIPTION
Use "order by" for a deterministic result. Always return the active
slice for a given URN, or the most recently expired slice if no active
slice exists.

Fixes #393.
