### PR TITLE
Fix a bug in lookup_project_attributes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,10 @@
 
 = GENI Clearinghouse Release Notes =
 
+== 2.1.1 ==
+ * Fix a bug in lookup_project_attributes where the PROJECT_UID option was
+   required to be a list. Allow it to be a single UID. (#400)
+
 == 2.1 ==
  * Migrate CH tables from geni-portal to geni-ch (#103).
  * Support lists of project_ids in option for lookup_project_attributes (#391).

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -1485,10 +1485,15 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         self.update_project_expirations(client_uuid, session)
 
         if "match" in options and "PROJECT_UID" in options["match"]:
-            project_ids = options["match"]["PROJECT_UID"]
+            project_id = options["match"]["PROJECT_UID"]
         else:
             name = from_project_urn(project_urn)
             project_id = self.get_project_id(session, "project_name", name)
+
+        # Ensure we have a list of project IDs for the "IN" db clause
+        if isinstance(project_id, list):
+            project_ids = project_id
+        else:
             project_ids = [project_id]
 
         q = session.query(self.db.PROJECT_ATTRIBUTE_TABLE )


### PR DESCRIPTION
Allow the PROJECT_UID option to be either a list or a single UUID.