### PR TITLE
Use 'not implemented' instead of 'argument error' for SA delete

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 
 == 2.4 ==
  * Migrate management scripts from geni-portal to geni-ch (#101)
+ * Raise not implemented error for delete slice and delete project (#398)
 
 == 2.3 ==
  * Add geni-revoke-member-certificate man page

--- a/plugins/chapiv1rpc/chapi/SliceAuthority.py
+++ b/plugins/chapiv1rpc/chapi/SliceAuthority.py
@@ -80,11 +80,13 @@ class SAv1Handler(HandlerBase):
             
     def delete(self, type, urn, credentials, options):
         if type == "SLICE":
-            return self._errorReturn(CHAPIv1ArgumentError("method delete not supported for SLICE"))
+          msg = "method delete not implemented for type %s" % (type)
+          return self._errorReturn(CHAPIv1NotImplementedError(msg))
         elif type == "SLIVER_INFO":
             result = self.delete_sliver_info(urn, credentials, options)
         elif type == "PROJECT":
-            result = self._errorReturn(CHAPIv1ArgumentError("method delete not supported for PROJECT"))
+          msg = "method delete not implemented for type %s" % (type)
+          return self._errorReturn(CHAPIv1NotImplementedError(msg))
         else:
              result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
         return result


### PR DESCRIPTION
Slice and project delete is not supported, but raises argument error. Use not implemented error instead.

Fixes #398 