### PR TITLE
Return dates as strings from SA create

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 
 == 2.4 ==
  * Migrate management scripts from geni-portal to geni-ch (#101)
+ * Return dates as strings from SA create (#397)
  * Raise not implemented error for delete slice and delete project (#398)
 
 == 2.3 ==

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -453,6 +453,12 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         session.add(object)
         # Force a flush of the session so that adding project/slice members works
         session.flush()
+
+        # Convert dates to strings per API
+        for k,v in ret.iteritems():
+            if isinstance(v, dt.datetime):
+              ret[k] = v.strftime(STANDARD_DATETIME_FORMAT)
+
         return self._successReturn(ret)
 
     # create a new slice


### PR DESCRIPTION
Per the API spec, all dates should be strings on the wire. Change
SA create to return dates as strings for both slices and projects.

Fixes #397 