### PR TITLE
Set default values in SA create

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
  * Migrate management scripts from geni-portal to geni-ch (#101)
  * Return dates as strings from SA create (#397)
  * Raise not implemented error for delete slice and delete project (#398)
+ * Set default values for slice and project creation (#414)
 
 == 2.3 ==
  * Add geni-revoke-member-certificate man page

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -482,6 +482,11 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         # fill in the fields of the object
         slice = Slice()
+
+        # Set default values for fields that may not get set
+        setattr(slice, SA.slice_field_mapping['SLICE_DESCRIPTION'], '')
+        setattr(slice, SA.slice_field_mapping['SLICE_EXPIRED'], False)
+
         project_urn = None
         for key, value in options["fields"].iteritems():
             if key == "SLICE_PROJECT_URN":
@@ -733,6 +738,11 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         # fill in the fields of the object
         project = Project()
+
+        # Set default values for fields that may not get set
+        setattr(project, SA.project_field_mapping['PROJECT_DESCRIPTION'], '')
+        setattr(project, SA.project_field_mapping['PROJECT_EXPIRED'], False)
+
         for key, value in options["fields"].iteritems():
             setattr(project, SA.project_field_mapping[key], value)
         project.creation = dt.datetime.utcnow()


### PR DESCRIPTION
Use default values for attributes that do not or may not get set
during creation of projects and slices to ensure that return values
comply with the API spec.

Fixes #414 