### PR TITLE
Validate requested expirations on create

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
  * Migrate management scripts from geni-portal to geni-ch (#101)
  * Return dates as strings from SA create (#397)
  * Raise not implemented error for delete slice and delete project (#398)
+ * Ensure now < slice expiration < max expiration (#413)
  * Set default values for slice and project creation (#414)
 
 == 2.3 ==

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@
  * Return dates as strings from SA create (#397)
  * Raise not implemented error for delete slice and delete project (#398)
  * Ensure now < slice expiration < max expiration (#413)
+ * Validate project expiration dates
  * Set default values for slice and project creation (#414)
 
 == 2.3 ==

--- a/plugins/chrm/ArgumentCheck.py
+++ b/plugins/chrm/ArgumentCheck.py
@@ -212,8 +212,8 @@ class FieldsArgumentCheck(ArgumentCheck):
                     properly_formed = True
                 except Exception, e:
                     pass
-            else:
-                # If there's no value, that's fine too
+            elif value is None:
+                # If the value is None, that's fine
                 properly_formed = True
         elif field_type == "EMAIL":
             properly_formed = value.find('@')>= 0 and value.find('.') >= 0

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -533,19 +533,30 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                                             name + ' in project ' + project_name)
 
         slice.creation = dt.datetime.utcnow()
-        # FIXME: Why check if slice.expiration is set. We are creating the slice here - how can it be set?
+
+        # Set expiration if none was set
         if not slice.expiration:
-            # FIXME: Externalize the #7 here
             slice.expiration = slice.creation + relativedelta(days=SA.SLICE_DEFAULT_LIFE_DAYS)
         else:
-            # Make timzeone UTC naive
             slice.expiration = dateutil.parser.parse(slice.expiration)
+
+        # Make timzeone UTC naive
+        if slice.expiration.tzinfo:
             slice.expiration = slice.expiration.astimezone(dateutil.tz.tzutc())
             slice.expiration = slice.expiration.replace(tzinfo=None)
 
         # if project expiration is sooner than slice expiration, use project expiration
         if project_expiration != None and slice.expiration > project_expiration:
             slice.expiration = project_expiration
+
+        now = dt.datetime.utcnow()
+        if slice.expiration < now:
+            raise CHAPIv1ArgumentError('Requested expiration is in the past')
+
+        # Limit the max expiration to the max renewal period
+        max_exp = now + relativedelta(days=SA.SLICE_MAX_RENEWAL_DAYS)
+        if slice.expiration > max_exp:
+            slice.expiration = max_exp
 
         slice.slice_id = str(uuid.uuid4())
         slice.owner_id = client_uuid

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -723,6 +723,22 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         return result
 
+    def _validate_project_expiration(self, expiration):
+        if expiration:
+            result = dateutil.parser.parse(expiration)
+            # convert to UTC naive
+            if result.tzinfo:
+                result = result.astimezone(dateutil.tz.tzutc())
+                result = result.replace(tzinfo=None)
+
+            now = dt.datetime.utcnow()
+            if result < now:
+                msg = 'Requested expiration is in the past'
+                raise CHAPIv1ArgumentError(msg)
+        else:
+            result = None
+        return result
+
     # create a new project
     def create_project(self, client_cert, credentials, options, session):
 
@@ -757,8 +773,9 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         for key, value in options["fields"].iteritems():
             setattr(project, SA.project_field_mapping[key], value)
         project.creation = dt.datetime.utcnow()
-        # FIXME: Must project expiration be in UTC?
-        if project.expiration == "": project.expiration=None
+
+        project.expiration = self._validate_project_expiration(project.expiration)
+
         project.project_id = str(uuid.uuid4())
 
         # FIXME: Real project email!


### PR DESCRIPTION
When creating slices and projects, do a better job validating requested expirations. Raise an argument error if the expiration is in the past. Limit slice expiration to max renewal date. Convert expirations to UTC consistently. Do a better job filtering bad input for project expirations.

Fixes #413 