### PR TITLE
Ensure fields exist before updating

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
  * Migrate management scripts from geni-portal to geni-ch (#101)
  * Return dates as strings from SA create (#397)
  * Raise not implemented error for delete slice and delete project (#398)
+ * Ensure fields exist before updating (#411)
  * Ensure now < slice expiration < max expiration (#413)
  * Validate project expiration dates
  * Set default values for slice and project creation (#414)

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -838,6 +838,8 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         project_uuid = self.get_project_id(session, 'project_name', name)
         if not project_uuid:
             raise CHAPIv1ArgumentError('No project found with urn ' + project_urn)
+        if not options['fields']:
+            raise CHAPIv1ArgumentError('No fields to update')
         q = session.query(Project)
         q = q.filter(getattr(Project, "project_name") == name)
         updates = {}


### PR DESCRIPTION
Avoid an ugly database error by ensuring that there are fields to
update before executing the query.

Fixes #411 