### PR TITLE
Return last name to monitoring when present.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@
  * Ensure now < slice expiration < max expiration (#413)
  * Validate project expiration dates
  * Set default values for slice and project creation (#414)
+ * Return last_name to monitoring when present (#424)
 
 == 2.3 ==
  * Add geni-revoke-member-certificate man page

--- a/plugins/opsmon/OpsMon.py
+++ b/plugins/opsmon/OpsMon.py
@@ -237,7 +237,7 @@ class OpsMonHandler:
             if row.name == 'displayName': user_fullname = row.value
             if row.name == 'email_address': user_email = row.value
             if row.name == 'first_name' : user_firstname = row.value
-            if row.name == 'lsst_name' : user_lastname = row.value
+            if row.name == 'last_name' : user_lastname = row.value
             if row.name == 'urn' : user_urn = row.value
 
         if user_fullname is None:


### PR DESCRIPTION
Fix a typo in the monitoring service that caused last name to be None
when it is present and display name is missing.