### PR TITLE
Stop cc'ing on cert expiring email

### DIFF
--- a/bin/geni-expiring-certs.in
+++ b/bin/geni-expiring-certs.in
@@ -93,7 +93,8 @@ class Notifier:
         msg['Subject'] = subject
         msg['From'] = from_addr
         msg['To'] = address
-        msg['Cc'] = reply_to
+        # Stop cc'ing, it just creates inbox clutter
+        # msg['Cc'] = reply_to
         msg['Reply-To'] = reply_to
         s = smtplib.SMTP('localhost')
         s.sendmail(from_addr, [address, reply_to], msg.as_string())


### PR DESCRIPTION
The certificate expiring emails create inbox clutter. Drop the CC and
only send them to the individual whose certificate is expiring.