### PR TITLE
Stop CC'ing on expiring certs email

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 # [Release 2.7](https://github.com/GENI-NSF/geni-ch/milestones/2.6)
 
+* Stop CC'ing on expiring certificate email
+  ([#441](https://github.com/GENI-NSF/geni-ch/issues/441))
+
 # [Release 2.6](https://github.com/GENI-NSF/geni-ch/milestones/2.6)
 
 * Skip SQL in clause when collection is empty

--- a/bin/geni-expiring-certs.in
+++ b/bin/geni-expiring-certs.in
@@ -97,7 +97,7 @@ class Notifier:
         # msg['Cc'] = reply_to
         msg['Reply-To'] = reply_to
         s = smtplib.SMTP('localhost')
-        s.sendmail(from_addr, [address, reply_to], msg.as_string())
+        s.sendmail(from_addr, [address], msg.as_string())
         s.quit()
 
 def init_logging(options):


### PR DESCRIPTION
Fixes #441 

To test, check the mail.log at the time the expiring certificates cron job runs for a set of email going out.
