### PR TITLE
Allow SLICE_PROJECT_URN to designate project subject

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,9 @@
 
 = GENI Clearinghouse Release Notes =
 
+== 1.30 ==
+ * Allow SLICE_PROJECT_URN to allow determining subject in ABACGuard (#442).
+
 == 1.29 ==
  * remove hard-coded names in SAv1Implementation.py, 
    MAv1Implementation.py and cert-utils.py (#25)

--- a/plugins/chrm/ABACGuard.py
+++ b/plugins/chrm/ABACGuard.py
@@ -233,6 +233,8 @@ class SubjectInvocationCheck(InvocationCheck):
             # Pulling project out of match
             if "PROJECT_URN" in match_option:
                 urns = match_option['PROJECT_URN']
+            elif "SLICE_PROJECT_URN" in match_option:
+                urns = match_option['SLICE_PROJECT_URN']
             elif "PROJECT_UID" in match_option:
                 project_uids = match_option['PROJECT_UID']
                 if not isinstance(project_uids, list): 


### PR DESCRIPTION
Allow SLICE_PROJECT_URN to designate project subject (e.g. lookup_slices by project)

Fixes #442 