### PR TITLE
Configure logging in client.py

### DIFF
--- a/tools/client.py
+++ b/tools/client.py
@@ -115,7 +115,7 @@ def add_attribute(attributes, int_arg, uuid_arg):
         attributes['SLICE'] = uuid_arg
         
 def main(args = sys.argv, do_print=True):
-
+    logging.basicConfig()
     opts, args = parseOptions(args)
     client_options = json.loads(opts.options)
     if opts.options_file:


### PR DESCRIPTION
Logging fails in client.py if a message is logged at warn level or
above. Configure logging so the logged error message shows up.