### PR TITLE
Reduce use of AMsoil config at runtime

### DIFF
--- a/plugins/chapiv1rpc/chapi/HandlerBase.py
+++ b/plugins/chapiv1rpc/chapi/HandlerBase.py
@@ -42,6 +42,8 @@ class HandlerBase(xmlrpc.Dispatcher):
         self._guard = None
         self._trusted_roots = None
         self._trusted_roots = self.getTrustedRoots()
+        config = pm.getService('config')
+        self._maintenance_file = config.get('geni.maintenance_outage_location')
 
     # Get list of trusted roots for handler
     # If not set, initialize from chapiv1rpc.ch_cert_root directory
@@ -102,4 +104,5 @@ class HandlerBase(xmlrpc.Dispatcher):
                 self._logger.error(traceback.format_exc())
         return {'code' :  e.code , 'value' : None, 'output' : str(e) }
         
-
+    def maintenanceOutage(self):
+        return os.path.exists(self._maintenance_file)

--- a/plugins/chapiv1rpc/chapi/MethodContext.py
+++ b/plugins/chapiv1rpc/chapi/MethodContext.py
@@ -138,11 +138,7 @@ class MethodContext:
         clearinghouse during a maintenance outage.
 
         """
-        config = pm.getService('config')
-        maintenance_outage_location = \
-            config.get('geni.maintenance_outage_location')
-        outage_mode = os.path.exists(maintenance_outage_location)
-        if outage_mode:
+        if self._handler.maintenanceOutage():
             if self._session and self._client_cert:
                 user_urn = get_urn_from_cert(self._client_cert)
                 is_operator = lookup_operator_privilege(user_urn,

--- a/plugins/chrm/ABACGuard.py
+++ b/plugins/chrm/ABACGuard.py
@@ -622,11 +622,13 @@ class SubjectInvocationCheck(InvocationCheck):
 
         # Validate subject arguments
         for subject_type, subjects_of_type in subjects.items():
-            ensure_valid_urns(subject_type, subjects_of_type, session)
+            ensure_valid_urns(subject_type, subjects_of_type, session,
+                              self.authority)
 
         # Validate non subject arguments
         for subject_type, subjects_of_type in nonsubjects.items():
-            ensure_valid_urns(subject_type, subjects_of_type, session)
+            ensure_valid_urns(subject_type, subjects_of_type, session,
+                              self.authority)
 
         return subjects
 

--- a/plugins/chrm/ABACGuard.py
+++ b/plugins/chrm/ABACGuard.py
@@ -81,7 +81,7 @@ class InvocationCheck(object):
 # a given method on all the subjects of a given method invocation
 class SubjectInvocationCheck(InvocationCheck):
 
-    def __init__(self, policies, assertions):
+    def __init__(self, guard, policies, assertions):
         self._policies = policies
         if not policies: self._policies = []
         if policies and not isinstance(policies, list):
@@ -92,9 +92,9 @@ class SubjectInvocationCheck(InvocationCheck):
         if assertions and not isinstance(assertions, list):
             self._assertions = [assertions]
 
-        self.config = pm.getService('config')
-        self.key_file = self.config.get("chapiv1rpc.ch_key")
-        self.cert_file = self.config.get("chapiv1rpc.ch_cert")
+        self.key_file = guard.key_file
+        self.cert_file = guard.cert_file
+        self.authority = guard.authority
         self._verbose = False # Set this to True for verbose output
 
     # All recognized binding types (variables that can be
@@ -397,7 +397,7 @@ class SubjectInvocationCheck(InvocationCheck):
                                         subjects, bindings,
                                         options, arguments, session):
 
-        authority = pm.getService('config').get("chrm.authority")
+        authority = self.authority
 
 #        chapi_info('gen_bindings', 
 #                   "Subject Type: %s; bindings: %s; subjects: %s" % \
@@ -770,6 +770,11 @@ class ABACGuardBase(GuardBase):
     def __init__(self):
         GuardBase.__init__(self)
         self.db = pm.getService('chdbengine')
+        self.config = pm.getService('config')
+        self.key_file = self.config.get("chapiv1rpc.ch_key")
+        self.cert_file = self.config.get("chapiv1rpc.ch_cert")
+        self.authority = self.config.get("chrm.authority")
+
         #mapper(MemberAttribute, self.db.MEMBER_ATTRIBUTE_TABLE)
 
     # Base class: Provide a list of argument checks, 
@@ -842,10 +847,10 @@ class ABACGuardBase(GuardBase):
 # Method to convert
 # dictionary of method => arguments for creating SubjectInvocationChecks 
 #into a dictionary method => SubjectInvocationCheck
-def create_subject_invocation_checks(check_specs):
+def create_subject_invocation_checks(guard, check_specs):
     checks = {}
     for method, args in check_specs.items():
         policies = args['policies']
         assertions = args['assertions']
-        checks[method] = SubjectInvocationCheck(policies, assertions)
+        checks[method] = SubjectInvocationCheck(guard, policies, assertions)
     return checks

--- a/plugins/chrm/CHDatabaseEngine.py
+++ b/plugins/chrm/CHDatabaseEngine.py
@@ -25,6 +25,7 @@ import amsoil.core.pluginmanager as pm
 from sqlalchemy import *
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
+import logging
 
 Base = declarative_base()
 
@@ -45,6 +46,7 @@ class CHDatabaseEngine:
         config = pm.getService('config')
         self.db_url = config.get('chrm.db_url')
         self.db = create_engine(self.db_url)
+        # logging.getLogger('sqlalchemy').setLevel(logging.INFO)
         self.session_class = sessionmaker(bind=self.db)
         self.metadata = MetaData(self.db)
         Base.metadata.create_all(self.db)

--- a/plugins/csrm/CredentialStore.py
+++ b/plugins/csrm/CredentialStore.py
@@ -244,7 +244,7 @@ class CSv1Guard(ABACGuardBase):
             policies = \
                 parse_method_policies(CSv1Guard.policies_filename)
             self.INVOCATION_CHECK_FOR_METHOD = \
-                create_subject_invocation_checks(policies)
+                create_subject_invocation_checks(self, policies)
         if self.INVOCATION_CHECK_FOR_METHOD.has_key(method):
             return self.INVOCATION_CHECK_FOR_METHOD[method]
         return None

--- a/plugins/logging/Logging.py
+++ b/plugins/logging/Logging.py
@@ -296,7 +296,7 @@ class Loggingv1Guard(ABACGuardBase):
             policies = \
                 parse_method_policies(Loggingv1Guard.policies_filename)
             self.INVOCATION_CHECK_FOR_METHOD = \
-                create_subject_invocation_checks(policies)
+                create_subject_invocation_checks(self, policies)
         if self.INVOCATION_CHECK_FOR_METHOD.has_key(method):
             return self.INVOCATION_CHECK_FOR_METHOD[method]
         return None

--- a/plugins/marm/MAv1Guard.py
+++ b/plugins/marm/MAv1Guard.py
@@ -150,7 +150,7 @@ class MAv1Guard(ABACGuardBase):
             policies = \
                 parse_method_policies(self.policies_filename)
             self.INVOCATION_CHECK_FOR_METHOD = \
-                create_subject_invocation_checks(policies)
+                create_subject_invocation_checks(self, policies)
         if self.INVOCATION_CHECK_FOR_METHOD.has_key(method):
             return self.INVOCATION_CHECK_FOR_METHOD[method]
         return None

--- a/plugins/sarm/SAv1Guard.py
+++ b/plugins/sarm/SAv1Guard.py
@@ -147,7 +147,7 @@ class SAv1Guard(ABACGuardBase):
             policies = \
                 parse_method_policies(self.policies_filename)
             self.INVOCATION_CHECK_FOR_METHOD = \
-                create_subject_invocation_checks(policies)
+                create_subject_invocation_checks(self, policies)
         if self.INVOCATION_CHECK_FOR_METHOD.has_key(method):
             return self.INVOCATION_CHECK_FOR_METHOD[method]
         return None

--- a/tools/geni_utils.py
+++ b/tools/geni_utils.py
@@ -39,9 +39,7 @@ def to_project_urn(authority, project_name):
         (authority, project_name)
 
 # Turn a row with project name into a project URN
-def row_to_project_urn(row):
-    config = pm.getService('config')
-    authority = config.get("chrm.authority")
+def row_to_project_urn(authority, row):
     return to_project_urn(authority, row.project_name)
 
 def urn_for_slice(slice_name, project_name):

--- a/tools/guard_utils.py
+++ b/tools/guard_utils.py
@@ -230,8 +230,8 @@ def convert_slice_uid_to_urn(slice_uid, session):
 # and return a urn or list of urns
 def convert_project_uid_to_urn(project_uid, session):
     db = pm.getService('chdbengine')
-    config = pm.getService('config')
-    authority = config.get("chrm.authority")
+    sa = pm.getService('sav1handler')
+    authority = sa.getDelegate().authority
 
     project_uids = project_uid
     if not isinstance(project_uid, list): project_uids = [project_uid]
@@ -267,8 +267,8 @@ def convert_project_uid_to_urn(project_uid, session):
 # and return a uid or list of uid
 def convert_project_urn_to_uid(project_urn, session):
     db = pm.getService('chdbengine')
-    config = pm.getService('config')
-    authority = config.get("chrm.authority")
+    sa = pm.getService('sav1handler')
+    authority = sa.getDelegate().authority
 
     project_urns = project_urn
     if not isinstance(project_urn, list): project_urns = [project_urn]

--- a/tools/guard_utils.py
+++ b/tools/guard_utils.py
@@ -129,12 +129,11 @@ def validate_uid_list(uids, cache, label):
     return good_urns
 
 # Look at a list of URN's of a given type and determine that they are all valid
-def ensure_valid_urns(urn_type, urns, session):
+def ensure_valid_urns(urn_type, urns, session, authority):
 #    chapi_info("ENSURE_VALID_URNS", "%s %s" % (urn_type, urns))
     if not isinstance(urns, list): urns = [urns]
     db = pm.getService('chdbengine')
     if urn_type == 'PROJECT_URN':
-        authority = pm.getService('config').get("chrm.authority")
         cache = cache_get('project_urns')
         not_found_urns = [urn for urn in urns if urn not in cache]
         if len(not_found_urns) == 0:

--- a/tools/guard_utils.py
+++ b/tools/guard_utils.py
@@ -307,8 +307,8 @@ def convert_project_urn_to_name(urn, session):
 
 # Convert a project name to project urn
 def convert_project_name_to_urn(name, session):
-    config = pm.getService('config')
-    authority = config.get("chrm.authority")
+    sa = pm.getService('sav1handler')
+    authority = sa.getDelegate().authority
     return to_project_urn(authority, name)
 
 # Take a uid or list of uids, make sure they're all in the cache


### PR DESCRIPTION
AMsoil's config module accesses SQLite at runtime. SLQAlchemy serializes calls to SQLite so multiple clearinghouse calls interfere with each other when they need data from the config module. Some calls are intensive in their calls to the config module, like the lookup_projects call when looking up all projects. 

Cache the data from the config module at startup time and use this cache at runtime. We do not expect that information to change during the run. Changes already require a restart so it's ok to cache the values at startup.
