### PR TITLE
Allow KEY_TYPE as an argument to MA.create_key()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # GENI Clearinghouse Release Notes
 
-# [Release 2.8](https://github.com/GENI-NSF/geni-ch/milestones/2.8)
+# [Release 2.9](https://github.com/GENI-NSF/geni-ch/milestones/2.9)
 
+* Allow KEY_TYPE as an argument to MA.create_key()
+  ([#458](https://github.com/GENI-NSF/geni-ch/issues/458))
 
 # [Release 2.8](https://github.com/GENI-NSF/geni-ch/milestones/2.8)
 

--- a/tools/MA_constants.py
+++ b/tools/MA_constants.py
@@ -188,7 +188,7 @@ match_fields = [
 required_create_key_fields = ["KEY_PUBLIC", "KEY_MEMBER"]
 allowed_create_key_fields = [
     "KEY_PUBLIC", "KEY_PRIVATE", "KEY_DESCRIPTION",
-    "_GENI_KEY_FILENAME", "KEY_MEMBER"
+    "_GENI_KEY_FILENAME", "KEY_MEMBER", "KEY_TYPE"
 ]
 updatable_key_fields = ["KEY_DESCRIPTION", "_GENI_KEY_FILENAME"]
 


### PR DESCRIPTION
Make KEY_TYPE an optional (i.e. 'allowed') field for `create_key()`. According to the spec it should be required but that would break existing clients and would need to be coordinated.

Fixes #458
