### PR TITLE
Restrict project names a bit more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 
 * Remove PGCH service
   ([#474](https://github.com/GENI-NSF/geni-ch/issues/474))
+* Restrict project names a little bit more
+  ([#480](https://github.com/GENI-NSF/geni-ch/issues/480))
 
 # [Release 2.10](https://github.com/GENI-NSF/geni-ch/milestones/2.10)
 

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -748,17 +748,12 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         self.update_project_expirations(client_uuid, session)
 
         name = options["fields"]["PROJECT_NAME"]
-        # check that project name is valid
-        if ' ' in name:
-            raise CHAPIv1ArgumentError('Project name may not contain spaces.')
-        elif len(name) > 32: # FIXME: Externalize this
-            raise CHAPIv1ArgumentError('Project name %s is too long - use at most 32 characters.' %name)
-            
-        # FIXME: Put this in a constants file
-        pattern = '^[a-zA-Z0-9][a-zA-Z0-9-_]{0,31}$'
-        valid = re.match(pattern,name)
-        if valid == None:
-            raise CHAPIv1ArgumentError('Project name %s is invalid - use at most 32 alphanumeric characters or hyphen or underscore. No leading hyphen or underscore.' %name)
+        valid = re.match(SA.PROJECT_NAME_REGEX, name)
+        if not valid:
+            msg = ('Project name %s is invalid. Use at most 32 alphanumeric'
+                   + ' characters or hyphen or underscore. No leading hyphen'
+                   + ' or underscore.')
+            raise CHAPIv1ArgumentError(msg % (name))
         
         # check that project does not already exist
         if self.get_project_id(session, "project_name", name):

--- a/tools/SA_constants.py
+++ b/tools/SA_constants.py
@@ -144,7 +144,13 @@ project_request_columns = [
 ]
 
 PROJECT_DEFAULT_INVITATION_EXPIRATION_HOURS = 72
-# FIXME: project name length, regex
+
+# Project name rules:
+#  - Min length 2
+#  - Max length 32
+#  - First character alphabetic
+#  - Subsequent characters alphanumber plus hyphen and underscore
+PROJECT_NAME_REGEX = '^[a-zA-Z][a-zA-Z0-9-_]{1,31}$'
 
 project_request_field_mapping = {
     'id' : 'id', 


### PR DESCRIPTION
Make minimum length 2 instead of 1. Require a leading alphabetic
character instead of allowing a leading alphanumeric (i.e. disallow
leading numbers). Externalize the regex to a constants file and clean
up the error checking.

Fixes #480 