### PR TITLE
Remove getenv call, use __file__

### DIFF
--- a/tools/ABACManager.py
+++ b/tools/ABACManager.py
@@ -100,9 +100,8 @@ def execute_abac_query(query, id_certs, raw_assertions = []):
         create_abac_manager_config_file({}, id_certs, {}, raw_assertions)
 
     # Make the query call, pull result from stdout
-    chapi_home = os.getenv('CHAPIHOME')
-    chapi_tools = os.path.join(chapi_home, 'tools')
-    args = ['python', os.path.join(chapi_tools, 'ABACManager.py'),
+    abac_manager_path = os.path.abspath(__file__)
+    args = ['python', abac_manager_path,
             '--config=%s' % config_filename,
             '--query=%s' % query]
     chapi_debug("ABAC", "Exec ABAC Query ARGS = %s" % " ".join(args))
@@ -132,9 +131,8 @@ def generate_abac_credential(assertion, me_cert, me_key, id_certs):
         create_abac_manager_config_file(id_cert_files, id_certs, id_key_files, [])
 
      # Make the call, pull result from stdout
-    chapi_home = os.getenv('CHAPIHOME')
-    chapi_tools = os.path.join(chapi_home, 'tools')
-    args = ['python', os.path.join(chapi_tools, 'ABACManager.py'), 
+    abac_manager_path = os.path.abspath(__file__)
+    args = ['python', abac_manager_path,
                                    '--config=%s' % config_filename, 
                                    '--credential=%s' % assertion]
     cred = grab_output_from_subprocess(args)


### PR DESCRIPTION
Use __file__ instead of getenv to locate the current file on the
filesystem. getenv doesn't work in the WSGI world, at least the way we
have it configured.