### PR TITLE
Hotfix 2.11.1 - fix XML-RPC responses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # GENI Clearinghouse Release Notes
 
+# [Release 2.11.1](https://github.com/GENI-NSF/geni-ch/milestones/2.11.1)
+
+## Changes
+
+* Fix XML-RPC responses
+([#492](https://github.com/GENI-NSF/geni-ch/issues/492))
+
 # [Release 2.11](https://github.com/GENI-NSF/geni-ch/milestones/2.11)
 
 ## Installation Notes

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([geni-chapi], [2.11], [portal-help@geni.net])
+AC_INIT([geni-chapi], [2.11.1], [portal-help@geni.net])
 AM_INIT_AUTOMAKE([foreign -Wall -Wno-portability])
 AC_PROG_MKDIR_P
 AC_PROG_INSTALL

--- a/geni-chapi.spec
+++ b/geni-chapi.spec
@@ -1,5 +1,5 @@
 Name:           geni-chapi
-Version:        2.11
+Version:        2.11.1
 Release:        1%{?dist}
 Summary:        GENI clearinghouse
 BuildArch:      noarch

--- a/tools/ch_server.py
+++ b/tools/ch_server.py
@@ -72,7 +72,7 @@ def application(environ, start_response):
     except Exception as e:
         msg = "%s: %s" % (type(e).__name__, str(e))
         fault = xmlrpclib.Fault(1, msg)
-        response = xmlrpclib.dumps(fault, allow_none=True)
+        response = xmlrpclib.dumps(fault, methodresponse=True, allow_none=True)
         return [response]
 
 
@@ -114,7 +114,7 @@ def handle_XMLRPC_call(environ):
         # Always clear the environment after the call is complete,
         # even if there was an exception
         envService.clearEnvironment()
-    response = xmlrpclib.dumps((method_response, ), allow_none=True)
+    response = xmlrpclib.dumps((method_response,), methodresponse=True, allow_none=True)
     return response
 
 


### PR DESCRIPTION
Fix a regression with XML-RPC responses by returning the response in a method-response tag.