### PR TITLE
Add project credentials

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ## Changes
 
+* Provide project credentials via SA.get_credentials
+([#466](https://github.com/GENI-NSF/geni-ch/issues/466))
+
 ## Installation Notes
 
 # [Release 2.11.1](https://github.com/GENI-NSF/geni-ch/milestones/2.11.1)

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,3 +1,6 @@
+dist_pkgdata_DATA = \
+	project_credential.xml
+
 # Where Service Registry (SR) certificates get installed
 srcertsdir = $(pkgdatadir)/sr/certs
 

--- a/data/project_credential.xml
+++ b/data/project_credential.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<signed-credential xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.planet-lab.org/resources/sfa/credential.xsd" xsi:schemaLocation="http://www.planet-lab.org/resources/sfa/ext/policy/1 http://www.planet-lab.org/resources/sfa/ext/policy/1/policy.xsd">
+<credential xml:id="ref0">
+    <type>privilege</type>
+    <serial>@serial@</serial>
+    <owner_gid>@owner_certificate@</owner_gid>
+    <owner_urn>@owner_urn@</owner_urn>
+    <target_gid>@project_certificate@</target_gid>
+    <target_urn>@project_urn@</target_urn>
+    <uuid/>
+    <expires>@expiration@</expires>
+    <privileges>
+        <privilege>
+            <name>@project_privilege@</name>
+            <can_delegate>false</can_delegate>
+        </privilege>
+    </privileges>
+</credential>
+<signatures>
+    <Signature xmlns="http://www.w3.org/2000/09/xmldsig#" xml:id="Sig_ref0">
+    <SignedInfo>
+        <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+        <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+        <Reference URI="#ref0">
+            <Transforms>
+                <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            </Transforms>
+            <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <DigestValue/>
+        </Reference>
+    </SignedInfo>
+    <SignatureValue/>
+    <KeyInfo>
+        <X509Data>
+            <X509SubjectName/>
+            <X509IssuerSerial/>
+            <X509Certificate/>
+        </X509Data>
+        <KeyValue/>
+    </KeyInfo>
+</Signature>
+</signatures>
+</signed-credential>

--- a/etc/slice_authority_policy.json
+++ b/etc/slice_authority_policy.json
@@ -39,7 +39,7 @@
       ]
    },
 
-  "get_credentials" :  {
+  "get_slice_credentials" :  {
      "__DOC__" : "Slice lead/admin/member or operators can get slice cred",
       "assertions" : [
         "ME.IS_$ROLE_$SLICE<-CALLER"

--- a/etc/slice_authority_policy.json
+++ b/etc/slice_authority_policy.json
@@ -8,8 +8,8 @@
 	],
       "policies" : [
         "ME.MAY_$METHOD<-ME.IS_OPERATOR",
-        "ME.MAY_$METHOD_$PROJECT<-ME.IS_LEAD_$PROJECT", 
-        "ME.MAY_$METHOD_$PROJECT<-ME.IS_ADMIN_$PROJECT", 
+        "ME.MAY_$METHOD_$PROJECT<-ME.IS_LEAD_$PROJECT",
+        "ME.MAY_$METHOD_$PROJECT<-ME.IS_ADMIN_$PROJECT",
         "ME.MAY_$METHOD_$PROJECT<-ME.IS_MEMBER_$PROJECT"
       ]
    },
@@ -34,7 +34,7 @@
 	],
       "policies" : [
          "ME.MAY_$METHOD<-ME.IS_OPERATOR",
-         "ME.MAY_$METHOD_$SLICE<-ME.IS_LEAD_$SLICE", 
+         "ME.MAY_$METHOD_$SLICE<-ME.IS_LEAD_$SLICE",
          "ME.MAY_$METHOD_$SLICE<-ME.IS_ADMIN_$SLICE"
       ]
    },
@@ -46,7 +46,7 @@
 	],
      "policies" : [
         "ME.MAY_$METHOD<-ME.IS_OPERATOR",
-        "ME.MAY_$METHOD_$SLICE<-ME.IS_LEAD_$SLICE", 
+        "ME.MAY_$METHOD_$SLICE<-ME.IS_LEAD_$SLICE",
         "ME.MAY_$METHOD_$SLICE<-ME.IS_ADMIN_$SLICE",
         "ME.MAY_$METHOD_$SLICE<-ME.IS_MEMBER_$SLICE"
      ]
@@ -99,7 +99,7 @@
   "lookup_projects" : {
        "__DOC__" : "Anyone with legitimate cert can call lookup projects",
        "policies" : [
-         "ME.MAY_$METHOD<-CALLER" 
+         "ME.MAY_$METHOD<-CALLER"
        ]
      },
 
@@ -110,7 +110,7 @@
 	],
      "policies" : [
        "ME.MAY_$METHOD<-ME.IS_OPERATOR",
-       "ME.MAY_$METHOD_$PROJECT<-ME.IS_LEAD_$PROJECT", 
+       "ME.MAY_$METHOD_$PROJECT<-ME.IS_LEAD_$PROJECT",
        "ME.MAY_$METHOD_$PROJECT<-ME.IS_ADMIN_$PROJECT"
       ]
    },
@@ -161,7 +161,7 @@
     "policies" : [
       "ME.MAY_$METHOD<-ME.IS_OPERATOR",
       "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
-      "ME.MAY_$METHOD_$SLICE<-ME.IS_LEAD_$SLICE", 
+      "ME.MAY_$METHOD_$SLICE<-ME.IS_LEAD_$SLICE",
       "ME.MAY_$METHOD_$SLICE<-ME.IS_ADMIN_$SLICE",
       "ME.MAY_$METHOD_$SLICE<-ME.IS_MEMBER_$SLICE"
      ]
@@ -189,7 +189,7 @@
      "policies" : [
        "ME.MAY_$METHOD<-ME.IS_OPERATOR",
        "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
-       "ME.MAY_$METHOD_$SLICE<-ME.IS_LEAD_$SLICE", 
+       "ME.MAY_$METHOD_$SLICE<-ME.IS_LEAD_$SLICE",
        "ME.MAY_$METHOD_$SLICE<-ME.IS_ADMIN_$SLICE",
        "ME.MAY_$METHOD_$SLICE<-ME.IS_MEMBER_$SLICE"
      ]
@@ -246,7 +246,7 @@
       "ME.MAY_$METHOD<-ME.IS_OPERATOR",
       "ME.MAY_$METHOD<-ME.IS_LEAD_$REQUEST_ID",
       "ME.MAY_$METHOD<-ME.IS_ADMIN_$REQUEST_ID"
-    ] 
+    ]
    },
 
    "get_requests_by_user" :  {
@@ -285,8 +285,8 @@
 
   "get_request_by_id" : {
     "__DOC__" : [
-      "Only if you are an operator", 
-      "You are the requestor", 
+      "Only if you are an operator",
+      "You are the requestor",
       "or the lead/admin of the context"
     ],
     "assertions" : [
@@ -308,7 +308,7 @@
     ],
     "policies" : [
       "ME.MAY_$METHOD<-ME.IS_OPERATOR",
-      "ME.MAY_$METHOD_$PROJECT<-ME.IS_LEAD_$PROJECT", 
+      "ME.MAY_$METHOD_$PROJECT<-ME.IS_LEAD_$PROJECT",
       "ME.MAY_$METHOD_$PROJECT<-ME.IS_ADMIN_$PROJECT"
      ]
    },
@@ -322,6 +322,6 @@
        "ME.MAY_$METHOD<-ME.IS_OPERATOR",
        "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
      ]
-  }     
+  }
 
 }

--- a/etc/slice_authority_policy.json
+++ b/etc/slice_authority_policy.json
@@ -52,6 +52,19 @@
      ]
     },
 
+    "get_project_credentials" :  {
+       "__DOC__" : "Project lead/admin/member or operators can get project cred",
+        "assertions" : [
+          "ME.IS_$ROLE_$PROJECT<-CALLER"
+  	],
+       "policies" : [
+          "ME.MAY_$METHOD<-ME.IS_OPERATOR",
+          "ME.MAY_$METHOD_$PROJECT<-ME.IS_LEAD_$PROJECT",
+          "ME.MAY_$METHOD_$PROJECT<-ME.IS_ADMIN_$PROJECT",
+          "ME.MAY_$METHOD_$PROJECT<-ME.IS_MEMBER_$PROJECT"
+       ]
+      },
+
   "modify_slice_membership" : {
       "__DOC__" : "Operators and slice Lead/Admin can modify slice membership",
       "assertions" : [

--- a/geni-chapi.spec
+++ b/geni-chapi.spec
@@ -350,6 +350,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/%{name}/db/sr/postgresql/update-4.sql
 %{_datadir}/%{name}/db/sr/postgresql/update-5.sql
 %{_datadir}/%{name}/fastcgi.conf
+%{_datadir}/%{name}/project_credential.xml
 %{_datadir}/%{name}/templates/apache2.conf.tmpl
 %{_datadir}/%{name}/templates/ch-ssl.conf.tmpl
 %{_datadir}/%{name}/templates/chapi.ini.tmpl

--- a/plugins/chapiv1rpc/chapi/SliceAuthority.py
+++ b/plugins/chapiv1rpc/chapi/SliceAuthority.py
@@ -175,17 +175,17 @@ class SAv1Handler(HandlerBase):
         return mc._result
 
     # This call is protected
-    # Get credentials for given user with respect to given slice
-    # Authorization based on client cert and givencredentiabls
+    # Get credentials for given user with respect to given slice or project
+    # Authorization based on client cert and given credentials
     # Note the session is _not_ read_only because it may update_expirations
-    def get_credentials(self, slice_urn, credentials, options):
+    def get_credentials(self, urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'get_credentials',
-                           {'slice_urn' : slice_urn},
+                           {'urn' : urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
                     self._delegate.get_credentials(mc._client_cert,
-                                                   slice_urn,
+                                                   urn,
                                                    credentials,
                                                    options,
                                                    mc._session)

--- a/plugins/chapiv1rpc/chapi/SliceAuthority.py
+++ b/plugins/chapiv1rpc/chapi/SliceAuthority.py
@@ -206,6 +206,19 @@ class SAv1Handler(HandlerBase):
                                                    mc._session)
         return mc._result
 
+    def get_project_credentials(self, project_urn, credentials, options):
+        with MethodContext(self, SA_LOG_PREFIX, 'get_project_credentials',
+                           {'project_urn' : project_urn},
+                           credentials, options, read_only=False) as mc:
+            if not mc._error:
+                mc._result = \
+                    self._delegate.get_project_credentials(mc._client_cert,
+                                                   project_urn,
+                                                   credentials,
+                                                   options,
+                                                   mc._session)
+        return mc._result
+
     ## SLICE MEMBER SERVICE methods
 
     # Modify slice membership, adding, removing and changing roles

--- a/plugins/chapiv1rpc/chapi/SliceAuthority.py
+++ b/plugins/chapiv1rpc/chapi/SliceAuthority.py
@@ -64,7 +64,7 @@ class SAv1Handler(HandlerBase):
         else:
              result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
         return result
-            
+
     def update(self, type, urn, credentials, options):
         if type == "SLICE":
             result = self.update_slice(urn, credentials, options)
@@ -75,7 +75,7 @@ class SAv1Handler(HandlerBase):
         else:
             return self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
         return result
-            
+
     def delete(self, type, urn, credentials, options):
         if type == "SLICE":
           msg = "method delete not implemented for type %s" % (type)
@@ -88,7 +88,7 @@ class SAv1Handler(HandlerBase):
         else:
              result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
         return result
-            
+
     def lookup(self, type, credentials, options):
         if type == "SLICE":
             result = self.lookup_slices(credentials, options)
@@ -137,8 +137,8 @@ class SAv1Handler(HandlerBase):
                            {}, credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.create_slice(mc._client_cert, 
-                                                credentials, 
+                    self._delegate.create_slice(mc._client_cert,
+                                                credentials,
                                                 options,
                                                 mc._session)
         return mc._result
@@ -152,8 +152,8 @@ class SAv1Handler(HandlerBase):
                            {}, credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_slices(mc._client_cert, 
-                                                 credentials, 
+                    self._delegate.lookup_slices(mc._client_cert,
+                                                 credentials,
                                                  options,
                                                  mc._session)
         return mc._result
@@ -163,13 +163,13 @@ class SAv1Handler(HandlerBase):
     # Authorized by client cert and credentials
     def update_slice(self, slice_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'update_slice',
-                           {'slice_urn' : slice_urn}, 
+                           {'slice_urn' : slice_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.update_slice(mc._client_cert, 
-                                                slice_urn, 
-                                                credentials, 
+                    self._delegate.update_slice(mc._client_cert,
+                                                slice_urn,
+                                                credentials,
                                                 options,
                                                 mc._session)
         return mc._result
@@ -180,19 +180,19 @@ class SAv1Handler(HandlerBase):
     # Note the session is _not_ read_only because it may update_expirations
     def get_credentials(self, slice_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'get_credentials',
-                           {'slice_urn' : slice_urn}, 
+                           {'slice_urn' : slice_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.get_credentials(mc._client_cert, 
+                    self._delegate.get_credentials(mc._client_cert,
                                                    slice_urn,
-                                                   credentials, 
+                                                   credentials,
                                                    options,
                                                    mc._session)
         return mc._result
 
     ## SLICE MEMBER SERVICE methods
-    
+
     # Modify slice membership, adding, removing and changing roles
     # of members with respect to given slice
     # The list of members_to_add, members_to_remove, members_to_modify
@@ -200,16 +200,16 @@ class SAv1Handler(HandlerBase):
     # 'members_to_add' : List of {URN : ROLE} dictionaries
     # 'members_to_remove' : List of URNs
     # 'members_to_modify' : List of {URN : ROLE} dictionaries
-    def modify_slice_membership(self, slice_urn, 
+    def modify_slice_membership(self, slice_urn,
                                     credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'modify_slice_membership',
-                           {'slice_urn' : slice_urn}, 
+                           {'slice_urn' : slice_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.modify_slice_membership(mc._client_cert, 
+                    self._delegate.modify_slice_membership(mc._client_cert,
                                                            slice_urn,
-                                                           credentials, 
+                                                           credentials,
                                                            options,
                                                            mc._session)
         return mc._result
@@ -218,13 +218,13 @@ class SAv1Handler(HandlerBase):
     # Note the session is _not_ read_only because it may update_expirations
     def lookup_slice_members(self, slice_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'lookup_slice_members',
-                           {'slice_urn' : slice_urn}, 
+                           {'slice_urn' : slice_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_slice_members(mc._client_cert, 
+                    self._delegate.lookup_slice_members(mc._client_cert,
                                                            slice_urn,
-                                                           credentials, 
+                                                           credentials,
                                                            options,
                                                            mc._session)
         return mc._result
@@ -233,13 +233,13 @@ class SAv1Handler(HandlerBase):
     # Note the session is _not_ read_only because it may update_expirations
     def lookup_slices_for_member(self, member_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'lookup_slices_for_member',
-                           {'member_urn' : member_urn}, 
+                           {'member_urn' : member_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_slices_for_member(mc._client_cert, 
+                    self._delegate.lookup_slices_for_member(mc._client_cert,
                                                            member_urn,
-                                                           credentials, 
+                                                           credentials,
                                                            options,
                                                            mc._session)
         return mc._result
@@ -247,16 +247,16 @@ class SAv1Handler(HandlerBase):
     ## SLIVER INFO SERVICE methods
 
     # Create a record of sliver creation
-    # Provide a dictionary of required fields and return a 
+    # Provide a dictionary of required fields and return a
     # dictionary of completed fields for new records
     def create_sliver_info(self, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'create_sliver_info',
-                           {}, 
+                           {},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.create_sliver_info(mc._client_cert, 
-                                                      credentials, 
+                    self._delegate.create_sliver_info(mc._client_cert,
+                                                      credentials,
                                                       options,
                                                       mc._session)
         return mc._result
@@ -264,13 +264,13 @@ class SAv1Handler(HandlerBase):
     # Delete a sliver_info record of given sliver_urn
     def delete_sliver_info(self, sliver_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'delete_sliver_info',
-                           {'sliver_urn' : sliver_urn}, 
+                           {'sliver_urn' : sliver_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.delete_sliver_info(mc._client_cert, 
+                    self._delegate.delete_sliver_info(mc._client_cert,
                                                       sliver_urn,
-                                                      credentials, 
+                                                      credentials,
                                                       options,
                                                       mc._session)
         return mc._result
@@ -278,27 +278,27 @@ class SAv1Handler(HandlerBase):
     # Update the details of a sliver_info record of given sliver_urn
     def update_sliver_info(self, sliver_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'update_sliver_info',
-                           {'sliver_urn' : sliver_urn}, 
+                           {'sliver_urn' : sliver_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.update_sliver_info(mc._client_cert, 
+                    self._delegate.update_sliver_info(mc._client_cert,
                                                       sliver_urn,
-                                                      credentials, 
+                                                      credentials,
                                                       options,
                                                       mc._session)
         return mc._result
 
-    # Lookup sliver info for given match criteria 
+    # Lookup sliver info for given match criteria
     # return fields in given fillter driteria
     def lookup_sliver_info(self, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'lookup_sliver_info',
-                           {}, 
+                           {},
                            credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_sliver_info(mc._client_cert, 
-                                                      credentials, 
+                    self._delegate.lookup_sliver_info(mc._client_cert,
+                                                      credentials,
                                                       options,
                                                       mc._session)
         return mc._result
@@ -308,13 +308,13 @@ class SAv1Handler(HandlerBase):
     # Create project with given details in options
     def create_project(self, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'create_project',
-                           {}, 
-                           credentials, options, 
+                           {},
+                           credentials, options,
                            read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.create_project(mc._client_cert, 
-                                                  credentials, 
+                    self._delegate.create_project(mc._client_cert,
+                                                  credentials,
                                                   options,
                                                   mc._session)
         return mc._result
@@ -324,12 +324,12 @@ class SAv1Handler(HandlerBase):
     # Note the session is _not_ read_only because it may update_expirations
     def lookup_projects(self, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'lookup_projects',
-                           {}, 
+                           {},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_projects(mc._client_cert, 
-                                                   credentials, 
+                    self._delegate.lookup_projects(mc._client_cert,
+                                                   credentials,
                                                    options,
                                                    mc._session)
         return mc._result
@@ -337,20 +337,20 @@ class SAv1Handler(HandlerBase):
     # Update fields in given project object specified in options
     def update_project(self, project_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'update_project',
-                           {'project_urn' : project_urn}, 
+                           {'project_urn' : project_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.update_project(mc._client_cert, 
+                    self._delegate.update_project(mc._client_cert,
                                                   project_urn,
-                                                  credentials, 
+                                                  credentials,
                                                   options,
                                                   mc._session)
         return mc._result
 
 
     ## PROJECT MEMBER SERVICE methods
-    
+
     # Modify project membership, adding, removing and changing roles
     # of members with respect to given project
     # The list of members_to_add, members_to_remove, members_to_modify
@@ -358,16 +358,16 @@ class SAv1Handler(HandlerBase):
     # 'members_to_add' : List of {URN : ROLE} dictionaries
     # 'members_to_remove' : List of URNs
     # 'members_to_modify' : List of {URN : ROLE} dictionaries
-    def modify_project_membership(self, project_urn, 
+    def modify_project_membership(self, project_urn,
                                       credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'modify_project_membership',
-                           {'project_urn' : project_urn}, 
+                           {'project_urn' : project_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.modify_project_membership(mc._client_cert, 
+                    self._delegate.modify_project_membership(mc._client_cert,
                                                              project_urn,
-                                                             credentials, 
+                                                             credentials,
                                                              options,
                                                              mc._session)
         return mc._result
@@ -376,13 +376,13 @@ class SAv1Handler(HandlerBase):
     # Note the session is _not_ read_only because it may update_expirations
     def lookup_project_members(self, project_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'lookup_project_members',
-                           {'project_urn' : project_urn}, 
+                           {'project_urn' : project_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_project_members(mc._client_cert, 
+                    self._delegate.lookup_project_members(mc._client_cert,
                                                           project_urn,
-                                                          credentials, 
+                                                          credentials,
                                                           options,
                                                           mc._session)
         return mc._result
@@ -392,19 +392,19 @@ class SAv1Handler(HandlerBase):
     # Note the session is _not_ read_only because it may update_expirations
     def lookup_projects_for_member(self, member_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'lookup_projects_for_member',
-                           {'member_urn' : member_urn}, 
+                           {'member_urn' : member_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_projects_for_member(mc._client_cert, 
+                    self._delegate.lookup_projects_for_member(mc._client_cert,
                                                           member_urn,
-                                                          credentials, 
+                                                          credentials,
                                                           options,
                                                           mc._session)
         return mc._result
 
     ## PROJECT ATTRIBUTE SERVICE methods
-        
+
     # Lookup, add, or remove project attributes
     # of members with respect to given project
     # The name and value of the attribute to add
@@ -412,16 +412,16 @@ class SAv1Handler(HandlerBase):
     # 'attribute_to_add' : NAME,VALUE
     # 'attribute_to_remove' : NAME
     # Note the session is _not_ read_only because it may update_expirations
-    def lookup_project_attributes(self, project_urn, 
+    def lookup_project_attributes(self, project_urn,
                                  credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'lookup_project_attributes',
-                           {'project_urn' : project_urn}, 
+                           {'project_urn' : project_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_project_attributes(mc._client_cert, 
+                    self._delegate.lookup_project_attributes(mc._client_cert,
                                                              project_urn,
-                                                             credentials, 
+                                                             credentials,
                                                              options,
                                                              mc._session)
         return mc._result
@@ -433,13 +433,13 @@ class SAv1Handler(HandlerBase):
                                   project_urn, \
                                   credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'add_project_attribute',
-                           {'project_urn' : project_urn}, 
+                           {'project_urn' : project_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.add_project_attribute(mc._client_cert, 
+                    self._delegate.add_project_attribute(mc._client_cert,
                                                              project_urn,
-                                                             credentials, 
+                                                             credentials,
                                                              options,
                                                              mc._session)
         return mc._result
@@ -451,13 +451,13 @@ class SAv1Handler(HandlerBase):
                                      project_urn, \
                                      credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'remove_project_attribute',
-                           {'project_urn' : project_urn}, 
+                           {'project_urn' : project_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.remove_project_attribute(mc._client_cert, 
+                    self._delegate.remove_project_attribute(mc._client_cert,
                                                             project_urn,
-                                                            credentials, 
+                                                            credentials,
                                                             options,
                                                             mc._session)
         return mc._result
@@ -465,25 +465,25 @@ class SAv1Handler(HandlerBase):
 
     # Methods for handling pending project / slice requests and invitations
     # Note: Not part of standard Federation API
-    
-    def create_request(self, context_type, context_id, request_type, request_text, 
+
+    def create_request(self, context_type, context_id, request_type, request_text,
                        request_details, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'create_request',
                            {'context_type' : context_type,
-                            'context_id' : context_id, 
+                            'context_id' : context_id,
                             'request_type' : request_type,
                             'request_text' : request_text,
                             'request_details' : request_details},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.create_request(mc._client_cert, 
+                    self._delegate.create_request(mc._client_cert,
                                                   context_type,
                                                   context_id,
                                                   request_type,
                                                   request_text,
                                                   request_details,
-                                                  credentials, 
+                                                  credentials,
                                                   options,
                                                   mc._session)
         return mc._result
@@ -493,13 +493,13 @@ class SAv1Handler(HandlerBase):
                                     credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'resolve_pending_request',
                            {'context_type' : context_type,
-                            'request_id' : request_id, 
+                            'request_id' : request_id,
                             'resolution_status' : resolution_status,
                             'resolution_description' : resolution_description},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.resolve_pending_request(mc._client_cert, 
+                    self._delegate.resolve_pending_request(mc._client_cert,
                                                            context_type,
                                                            request_id,
                                                            resolution_status,
@@ -513,38 +513,38 @@ class SAv1Handler(HandlerBase):
                                      credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'get_requests_for_context',
                            {'context_type' : context_type,
-                            'context_id' : context_id, 
+                            'context_id' : context_id,
                             'status' : status},
                            credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.get_requests_for_context(mc._client_cert, 
+                    self._delegate.get_requests_for_context(mc._client_cert,
                                                             context_type,
                                                             context_id,
                                                             status,
-                                                            credentials, 
+                                                            credentials,
                                                             options,
                                                             mc._session)
         return mc._result
 
 
-    def get_requests_by_user(self, member_id, context_type, 
-                             context_id, status, 
+    def get_requests_by_user(self, member_id, context_type,
+                             context_id, status,
                              credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'get_requests_by_user',
                            {'member_id' : member_id,
                             'context_type' : context_type,
-                            'context_id' : context_id, 
+                            'context_id' : context_id,
                             'status' : status},
                            credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.get_requests_by_user(mc._client_cert, 
+                    self._delegate.get_requests_by_user(mc._client_cert,
                                                         member_id,
                                                         context_type,
                                                         context_id,
                                                         status,
-                                                        credentials, 
+                                                        credentials,
                                                         options,
                                                         mc._session)
         return mc._result
@@ -558,11 +558,11 @@ class SAv1Handler(HandlerBase):
                            credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.get_pending_requests_for_user(mc._client_cert, 
+                    self._delegate.get_pending_requests_for_user(mc._client_cert,
                                                                  member_id,
                                                                  context_type,
                                                                  context_id,
-                                                                 credentials, 
+                                                                 credentials,
                                                                  options,
                                                                  mc._session)
         return mc._result
@@ -577,7 +577,7 @@ class SAv1Handler(HandlerBase):
                            credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.get_number_of_pending_requests_for_user(mc._client_cert, 
+                    self._delegate.get_number_of_pending_requests_for_user(mc._client_cert,
                                                                            member_id,
                                                                            context_type,
                                                                            context_id,
@@ -593,10 +593,10 @@ class SAv1Handler(HandlerBase):
                            credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.get_request_by_id(mc._client_cert, 
+                    self._delegate.get_request_by_id(mc._client_cert,
                                                      request_id,
                                                      context_type,
-                                                     credentials, 
+                                                     credentials,
                                                      options,
                                                      mc._session)
         return mc._result
@@ -607,7 +607,7 @@ class SAv1Handler(HandlerBase):
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.invite_member(mc._client_cert, 
+                    self._delegate.invite_member(mc._client_cert,
                                                  role,
                                                  project_id,
                                                  credentials,
@@ -621,7 +621,7 @@ class SAv1Handler(HandlerBase):
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.accept_invitation(mc._client_cert, 
+                    self._delegate.accept_invitation(mc._client_cert,
                                                      invite_id,
                                                      member_id,
                                                      credentials,
@@ -634,12 +634,12 @@ class SAv1Handler(HandlerBase):
 # implemented in a derived class, and that derived class
 # must call setDelegate on the handler
 class SAv1DelegateBase(DelegateBase):
-    
+
     ## SLICE SERVICE methods
 
     def __init__(self):
         super(SAv1DelegateBase, self).__init__(sa_logger)
-    
+
     def get_version(self, options, session):
         raise CHAPIv1NotImplementedError('')
 
@@ -659,14 +659,14 @@ class SAv1DelegateBase(DelegateBase):
         raise CHAPIv1NotImplementedError('')
 
     # This call is protected
-    def get_credentials(self, client_cert, slice_urn, credentials, options, 
+    def get_credentials(self, client_cert, slice_urn, credentials, options,
                         session):
         raise CHAPIv1NotImplementedError('')
 
     ## SLICE MEMBER SERVICE methods
-    
+
     def modify_slice_membership(self,  \
-                                    client_cert, slice_urn, 
+                                    client_cert, slice_urn,
                                     credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
@@ -697,7 +697,7 @@ class SAv1DelegateBase(DelegateBase):
     def lookup_sliver_info(self, client_cert, credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
-    
+
     ## PROJECT SERVICE methods
 
     def create_project(self, client_cert, credentials, options, session):
@@ -706,14 +706,14 @@ class SAv1DelegateBase(DelegateBase):
     def lookup_projects(self, client_cert, credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
-    def update_project(self, client_cert, project_urn, credentials, 
+    def update_project(self, client_cert, project_urn, credentials,
                        options, session):
         raise CHAPIv1NotImplementedError('')
 
     ## PROJECT MEMBER SERVICE methods
-    
+
     def modify_project_membership(self,  \
-                                    client_cert, project_urn, 
+                                    client_cert, project_urn,
                                     credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
@@ -728,7 +728,7 @@ class SAv1DelegateBase(DelegateBase):
         raise CHAPIv1NotImplementedError('')
 
     ## PROJECT ATTRIBUTE SERVICE methods
-    
+
     def lookup_project_attributes(self,  \
                                       client_cert, project_urn,  \
                                       credentials, options, session):
@@ -793,9 +793,6 @@ class SAv1DelegateBase(DelegateBase):
                       credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
-    def accept_invitation(self, client_cert, invite_id, member_id, 
+    def accept_invitation(self, client_cert, invite_id, member_id,
                           credentials, options, session):
         raise CHAPIv1NotImplementedError('')
-
-
-    

--- a/plugins/chapiv1rpc/chapi/SliceAuthority.py
+++ b/plugins/chapiv1rpc/chapi/SliceAuthority.py
@@ -208,15 +208,15 @@ class SAv1Handler(HandlerBase):
 
     def get_project_credentials(self, project_urn, credentials, options):
         with MethodContext(self, SA_LOG_PREFIX, 'get_project_credentials',
-                           {'project_urn' : project_urn},
+                           {'project_urn': project_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
                     self._delegate.get_project_credentials(mc._client_cert,
-                                                   project_urn,
-                                                   credentials,
-                                                   options,
-                                                   mc._session)
+                                                           project_urn,
+                                                           credentials,
+                                                           options,
+                                                           mc._session)
         return mc._result
 
     ## SLICE MEMBER SERVICE methods

--- a/plugins/marm/MAv1Implementation.py
+++ b/plugins/marm/MAv1Implementation.py
@@ -1,24 +1,24 @@
-#----------------------------------------------------------------------         
+#----------------------------------------------------------------------
 # Copyright (c) 2011-2016 Raytheon BBN Technologies
-#                                                                               
-# Permission is hereby granted, free of charge, to any person obtaining         
-# a copy of this software and/or hardware specification (the "Work") to         
-# deal in the Work without restriction, including without limitation the        
-# rights to use, copy, modify, merge, publish, distribute, sublicense,          
-# and/or sell copies of the Work, and to permit persons to whom the Work        
-# is furnished to do so, subject to the following conditions:                   
-#                                                                               
-# The above copyright notice and this permission notice shall be                
-# included in all copies or substantial portions of the Work.                   
-#                                                                               
-# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS           
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF                    
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND                         
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT                   
-# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,                  
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,            
-# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS            
-# IN THE WORK.                                                                  
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and/or hardware specification (the "Work") to
+# deal in the Work without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Work, and to permit persons to whom the Work
+# is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Work.
+#
+# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+# IN THE WORK.
 #----------------------------------------------------------------------
 
 # Implementation of the Member Authority
@@ -142,7 +142,7 @@ def make_urn(authority, typ, name):
     return 'urn:publicid:IDN+'+authority+'+'+typ+'+'+name
 
 class MAv1Implementation(MAv1DelegateBase):
-    
+
     def __init__(self):
         super(MAv1Implementation, self).__init__()
         self.db = pm.getService('chdbengine')
@@ -379,13 +379,13 @@ class MAv1Implementation(MAv1DelegateBase):
         return self._successReturn(result)
 
     # This call is unprotected: no checking of credentials
-    def lookup_public_member_info(self, client_cert, 
+    def lookup_public_member_info(self, client_cert,
                                   credentials, options, session):
         result = self.lookup_member_info(options, MA.public_fields, session)
         return result
 
     # This call is protected
-    def lookup_private_member_info(self, client_cert, credentials, 
+    def lookup_private_member_info(self, client_cert, credentials,
                                    options, session):
         result = self.lookup_member_info(options, MA.private_fields, session)
         return result
@@ -394,8 +394,8 @@ class MAv1Implementation(MAv1DelegateBase):
     def lookup_public_identifying_member_info(self, client_cert,
                                               credentials, options, session):
         result = \
-            self.lookup_member_info(options, 
-                                    MA.public_fields + MA.identifying_fields, 
+            self.lookup_member_info(options,
+                                    MA.public_fields + MA.identifying_fields,
                                     session)
         return result
 
@@ -436,7 +436,7 @@ class MAv1Implementation(MAv1DelegateBase):
                                              'lookup_identifying_member_info', \
                                              options, {}, session)
 
-        # 2b. Call lookup_identifying_member_info with identifyable members 
+        # 2b. Call lookup_identifying_member_info with identifyable members
         #   with identifying fields
         identifying_options = {'match' : allowed_identifying_match, \
                                    'filter' : identifying_fields}
@@ -497,7 +497,7 @@ class MAv1Implementation(MAv1DelegateBase):
                 else:
                     raise CHAPIv1ArgumentError("Unknown member field %s" % field)
         return public_fields, identifying_fields, private_fields
-                
+
     def determine_allowed_match(self, client_cert, credentials, \
                                     ma_guard, method, options, \
                                     arguments, session):
@@ -544,7 +544,7 @@ class MAv1Implementation(MAv1DelegateBase):
 
 
     # This call is protected
-    def update_member_info(self, client_cert, member_urn, 
+    def update_member_info(self, client_cert, member_urn,
                            credentials, options, session):
         # determine whether self_asserted
         try:
@@ -558,7 +558,7 @@ class MAv1Implementation(MAv1DelegateBase):
         if len(uids) == 0:
             raise CHAPIv1ArgumentError('No member with URN ' + member_urn)
         uid = uids[0]
-        
+
         # do the update
         all_keys = {}
         for attr, value in options['fields'].iteritems():
@@ -571,7 +571,7 @@ class MAv1Implementation(MAv1DelegateBase):
                 all_keys[table][MA.field_mapping[attr]] = value
         for table, keys in all_keys.iteritems():
             self.update_keys(session, table, keys, uid)
-            
+
         result = self._successReturn(True)
         return result
 
@@ -636,7 +636,7 @@ class MAv1Implementation(MAv1DelegateBase):
             session.add(obj)
 
     # part of the API, mainly call get_all_credentials()
-    def get_credentials(self, client_cert, member_urn, 
+    def get_credentials(self, client_cert, member_urn,
                         credentials, options, session):
 
         uids = self.get_uids_for_attribute(session, "MEMBER_URN", member_urn)
@@ -658,7 +658,7 @@ class MAv1Implementation(MAv1DelegateBase):
         #chapi_debug(MA_LOG_PREFIX, 'GUC: outside certs = '+str(certs))
         certs = self.get_val_for_uid(session, OutsideCert, "certificate", uid)
         if not certs:
-            certs = self.get_val_for_uid(session, InsideKey, "certificate", 
+            certs = self.get_val_for_uid(session, InsideKey, "certificate",
                                          uid)
         if not certs:
             chapi_warn(MA_LOG_PREFIX, "Get Credentials found no cert for uid %s" % uid, {'user': get_email_from_cert(client_cert)})
@@ -700,7 +700,7 @@ class MAv1Implementation(MAv1DelegateBase):
         #chapi_debug(MA_LOG_PREFIX, 'GUC: cred = '+cred.save_to_string())
         return cred.save_to_string()
 
-    def create_member(self, client_cert, attributes, 
+    def create_member(self, client_cert, attributes,
                       credentials, options, session):
 
         user_email = get_email_from_cert(client_cert)
@@ -759,7 +759,7 @@ class MAv1Implementation(MAv1DelegateBase):
     # Implementation of KEY Service methods
 
     def create_key(self, client_cert, credentials, options, session):
-        
+
         user_email = get_email_from_cert(client_cert)
 
        # Check that all the fields are allowed to be updated
@@ -777,7 +777,7 @@ class MAv1Implementation(MAv1DelegateBase):
         lookup_member_id_options = {'match' : {'MEMBER_URN' : member_urn},
                                     'filter' : ['MEMBER_UID']}
         result = \
-            self.lookup_public_member_info(client_cert, credentials, 
+            self.lookup_public_member_info(client_cert, credentials,
                                            lookup_member_id_options,
                                            session)
         if result['code'] != NO_ERROR:
@@ -867,11 +867,11 @@ class MAv1Implementation(MAv1DelegateBase):
         # Handle key_member specially: it is not part of the SSH key table
         if 'KEY_MEMBER' in match_criteria.keys():
             member_urns = match_criteria['KEY_MEMBER']
-            if not isinstance(member_urns, types.ListType): 
+            if not isinstance(member_urns, types.ListType):
                     member_urns = [member_urns]
             if len(member_urns) == 0:
                 # FIXME: If you specify an empty list, what should the behavior be?
-                # ANSWER: This is fine. An empty list means 
+                # ANSWER: This is fine. An empty list means
                 # 'give me keys for no users' hence ' give me no keys'
                 q = q.filter(self.db.MEMBER_ATTRIBUTE_TABLE.c.value == None)
                 #  chapi_debug(MA_LOG_PREFIX, "lookup_keys had empty list of urns")
@@ -880,12 +880,12 @@ class MAv1Implementation(MAv1DelegateBase):
                 enabled, disabled = check_disabled_users(self.db, member_urns, session)
                 member_urns = enabled
                 if len(disabled) > 0:
-                    chapi_info(MA_LOG_PREFIX, 
-                               "Attempt to access SSH keys of disabled users %s" % 
+                    chapi_info(MA_LOG_PREFIX,
+                               "Attempt to access SSH keys of disabled users %s" %
                                disabled)
             del match_criteria['KEY_MEMBER']
 
-        q = add_filters(q, match_criteria, self.db.SSH_KEY_TABLE, 
+        q = add_filters(q, match_criteria, self.db.SSH_KEY_TABLE,
                         MA.key_field_mapping, session)
         rows = q.all()
 
@@ -909,7 +909,7 @@ class MAv1Implementation(MAv1DelegateBase):
                     key_data['KEY_ID'] = str(key_id)
 
 
-        # Strip out any KEY_PRIVATE fields from key returns not for the 
+        # Strip out any KEY_PRIVATE fields from key returns not for the
         # calling user
         member_urn = get_urn_from_cert(client_cert)
         for urn, all_key_fields in keys.items():
@@ -985,7 +985,7 @@ class MAv1Implementation(MAv1DelegateBase):
             raise Exception(msg % (member_id))
 
     # Member certificate methods
-    def create_certificate(self, client_cert, member_urn, 
+    def create_certificate(self, client_cert, member_urn,
                            credentials, options, session):
 
         user_email = get_email_from_cert(client_cert)
@@ -1085,7 +1085,7 @@ class MAv1Implementation(MAv1DelegateBase):
 
             # insert into MA_INSIDE_KEY_TABLENAME
             # (member_id, client_urn, certificate, private_key)
-            # values 
+            # values
             # (member_id, client_urn, cert, key)
             insert_values = {'client_urn' : client_urn,
                              'member_id' : str(member_id),
@@ -1134,7 +1134,7 @@ class MAv1Implementation(MAv1DelegateBase):
         return (len(rows)==0 or rows[0][0] == 'y')
 
     # enable/disable a user/member  (private)
-    def enable_user(self, client_cert, member_urn, enable_sense, 
+    def enable_user(self, client_cert, member_urn, enable_sense,
                     credentials, options, session):
         '''Mark a member/user as enabled or disabled.
         IFF enabled_sense is True, then user is unconditionally enabled, otherwise disabled.
@@ -1195,7 +1195,7 @@ class MAv1Implementation(MAv1DelegateBase):
 
     # send email about new lead/operator privilege
     def mail_new_privilege(self,member_id, privilege, session):
-        options = {'match' : {'MEMBER_UID' : member_id },'filter': ['_GENI_MEMBER_DISPLAYNAME','MEMBER_FIRSTNAME','MEMBER_LASTNAME','MEMBER_EMAIL']}  
+        options = {'match' : {'MEMBER_UID' : member_id },'filter': ['_GENI_MEMBER_DISPLAYNAME','MEMBER_FIRSTNAME','MEMBER_LASTNAME','MEMBER_EMAIL']}
         info = self.lookup_member_info(options, MA.identifying_fields, session)
         member_info = info['value']
         pretty_name = ""
@@ -1215,10 +1215,10 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
 
 """
         else:
-            subject = "You are now a GENI Operator" 
+            subject = "You are now a GENI Operator"
             msgbody += "You are now a GENI Operator on "
             msgbody += self.config.get("chrm.authority") + ".\n\n"
-        
+
         msgbody += "Sincerely,\n"
         msgbody += "GENI Clearinghouse operations\n"
 
@@ -1227,7 +1227,7 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
         send_email(tolist, unicode(self.ch_from_email),unicode(self.portal_help_email),subject,msgbody,cclist)
 
     #  member_privilege (private)
-    def add_member_privilege(self, client_cert, member_uid, privilege, 
+    def add_member_privilege(self, client_cert, member_uid, privilege,
                              credentials, options, session):
         '''Mark a member/user as having a particular contextless privilege.
         privilege must be either OPERATOR or PROJECT_LEAD.'''
@@ -1272,7 +1272,7 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
 
         return result
 
-    def revoke_member_privilege(self, client_cert, member_uid, 
+    def revoke_member_privilege(self, client_cert, member_uid,
                                 privilege, credentials, options, session):
         '''Mark a member/user as not having a particular contextless privilege.
         privilege must be either OPERATOR or PROJECT_LEAD.'''
@@ -1307,7 +1307,7 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
                 member_urn = row[0]
                 #get projects for which member is lead
 
-                projects = self._sa_handler._delegate.lookup_projects_for_member(client_cert, member_urn, 
+                projects = self._sa_handler._delegate.lookup_projects_for_member(client_cert, member_urn,
                                                                                  credentials, {}, session)
 
                 for project in projects['value']:
@@ -1315,7 +1315,7 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
                     if project['PROJECT_ROLE'] == 'LEAD':
                         project_urn = project['PROJECT_URN']
                         #look for authorized admin to be new lead
-                        members = self._sa_handler._delegate.lookup_project_members(client_cert, project_urn, 
+                        members = self._sa_handler._delegate.lookup_project_members(client_cert, project_urn,
                                                                                     credentials, {}, session)
                         for member in members['value']:
                             if member['PROJECT_ROLE'] == 'ADMIN':
@@ -1326,7 +1326,7 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
                                 if rows and rows[0][0] == 'true':
                                     row = self.get_attr_for_uid(session,"MEMBER_URN",member['PROJECT_MEMBER_UID'])
                                     new_lead_urn = row[0]
-                                    
+
                                     options = {'members_to_change':[{'PROJECT_MEMBER': member_urn,'PROJECT_ROLE':'MEMBER'}, \
                                                                         {'PROJECT_MEMBER': new_lead_urn,'PROJECT_ROLE':'LEAD'}]}
                                     result = self._sa_handler._delegate.modify_project_membership(client_cert, project['PROJECT_URN'], credentials, options, session)
@@ -1366,7 +1366,7 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
         return True
 
     #  add member_attribute (private)
-    def add_member_attribute(self, client_cert, member_urn, attr_name, attr_value, 
+    def add_member_attribute(self, client_cert, member_urn, attr_name, attr_value,
                              attr_self_assert,
                              credentials, options, session):
         user_email = get_email_from_cert(client_cert)
@@ -1431,7 +1431,7 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
 
         return result
 
-    def remove_member_attribute(self, client_cert, member_urn, attr_name, 
+    def remove_member_attribute(self, client_cert, member_urn, attr_name,
                                 credentials, options, session, attr_value=None):
         user_email = get_email_from_cert(client_cert)
         caller_urn = get_urn_from_cert(client_cert)
@@ -1513,10 +1513,10 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
         urns = []
         urns.append(member_urn)
         options = {\
-            "match" : {"MEMBER_URN" : urns}, 
-            "filter" : ["_GENI_MEMBER_DISPLAYNAME", "MEMBER_FIRSTNAME", 
+            "match" : {"MEMBER_URN" : urns},
+            "filter" : ["_GENI_MEMBER_DISPLAYNAME", "MEMBER_FIRSTNAME",
                         "MEMBER_LASTNAME", "MEMBER_EMAIL"]}
-        result = self.lookup_member_info(options, MA.identifying_fields, 
+        result = self.lookup_member_info(options, MA.identifying_fields,
                                          session)
         if result['code'] != NO_ERROR or member_urn not in result['value']:
             return member_urn

--- a/plugins/marm/MAv1Implementation.py
+++ b/plugins/marm/MAv1Implementation.py
@@ -51,6 +51,7 @@ from tools.guard_utils import *
 from tools.chapi_utils import *
 from tools.ABACManager import *
 from tools.mapped_tables import *
+from tools.geni_utils import *
 from chapi.MemberAuthority import MAv1DelegateBase
 from chapi.Exceptions import *
 import chapi.Parameters
@@ -129,17 +130,6 @@ def make_member_urn(cert, username):
     ma_urn = get_urn_from_cert(cert)
     ma_authority, ma_type, ma_name = parse_urn(ma_urn)
     return make_urn(ma_authority, 'user', username)
-
-def parse_urn(urn):
-    '''returns authority, type, name'''
-    m = re.search('urn:publicid:IDN\+([^\+]+)\+([^\+]+)\+([^\+]+)$', urn)
-    if m is not None:
-        return m.group(1), m.group(2), m.group(3)
-    else:
-        return None
-
-def make_urn(authority, typ, name):
-    return 'urn:publicid:IDN+'+authority+'+'+typ+'+'+name
 
 class MAv1Implementation(MAv1DelegateBase):
 

--- a/plugins/sarm/SAv1Guard.py
+++ b/plugins/sarm/SAv1Guard.py
@@ -51,9 +51,7 @@ class SAv1Guard(ABACGuardBase):
 
 
     # Set of argument checks indexed by method name
-    ARGUMENT_CHECK_FOR_METHOD = \
-        {
-
+    ARGUMENT_CHECK_FOR_METHOD = {
         # Argument checks for slice methods
         'create_slice' : \
             CreateArgumentCheck(SA.slice_mandatory_fields,\
@@ -68,8 +66,8 @@ class SAv1Guard(ABACGuardBase):
         'modify_slice_membership' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
         'lookup_slice_members' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
         'lookup_slices_for_member' : SimpleArgumentCheck({'member_urn' : 'URN'}),
-        'get_slice_credentials' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
-        'get_project_credentials' : SimpleArgumentCheck({'project_urn' : 'URN'}),
+        'get_slice_credentials': SimpleArgumentCheck({'slice_urn': 'URN'}),
+        'get_project_credentials': SimpleArgumentCheck({'project_urn': 'URN'}),
 
         # Argument checks for project methods
 

--- a/plugins/sarm/SAv1Guard.py
+++ b/plugins/sarm/SAv1Guard.py
@@ -68,7 +68,7 @@ class SAv1Guard(ABACGuardBase):
         'modify_slice_membership' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
         'lookup_slice_members' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
         'lookup_slices_for_member' : SimpleArgumentCheck({'member_urn' : 'URN'}),
-        'get_credentials' : SimpleArgumentCheck({'urn' : 'URN'}),
+        'get_slice_credentials' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
 
         # Argument checks for project methods
 

--- a/plugins/sarm/SAv1Guard.py
+++ b/plugins/sarm/SAv1Guard.py
@@ -69,6 +69,7 @@ class SAv1Guard(ABACGuardBase):
         'lookup_slice_members' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
         'lookup_slices_for_member' : SimpleArgumentCheck({'member_urn' : 'URN'}),
         'get_slice_credentials' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
+        'get_project_credentials' : SimpleArgumentCheck({'project_urn' : 'URN'}),
 
         # Argument checks for project methods
 

--- a/plugins/sarm/SAv1Guard.py
+++ b/plugins/sarm/SAv1Guard.py
@@ -36,7 +36,7 @@ class SAv1Guard(ABACGuardBase):
 #    def lookup_slices(self, credentials, options):
 #    def update_slice(self, slice_urn, credentials, options):
 #    def get_credentials(self, slice_urn, credentials, options):
-#    def modify_slice_membership(self, slice_urn, 
+#    def modify_slice_membership(self, slice_urn,
 #    def lookup_slice_members(self, slice_urn, credentials, options):
 #    def lookup_slices_for_member(self, member_urn, credentials, options):
 #    def register_aggregate(self, slice_urn, aggregate_url, credentials, opts):
@@ -45,7 +45,7 @@ class SAv1Guard(ABACGuardBase):
 #    def create_project(self, credentials, options):
 #    def lookup_projects(self, credentials, options):
 #    def update_project(self, project_urn, credentials, options):
-#    def modify_project_membership(self, project_urn, 
+#    def modify_project_membership(self, project_urn,
 #    def lookup_project_members(self, project_urn, credentials, options):
 #    def lookup_projects_for_member(self, member_urn, credentials, options):
 
@@ -60,7 +60,7 @@ class SAv1Guard(ABACGuardBase):
                                    SA.slice_supplemental_fields),
         'update_slice' : \
             UpdateArgumentCheck(SA.slice_mandatory_fields,\
-                                    SA.slice_supplemental_fields, 
+                                    SA.slice_supplemental_fields,
                                 {'slice_urn' : "URN"}),
         'lookup_slices' : \
             LookupArgumentCheck(SA.slice_mandatory_fields,\
@@ -88,19 +88,19 @@ class SAv1Guard(ABACGuardBase):
 
         # Argument checks for sliver info aggregate methods
         'create_sliver_info' : CreateArgumentCheck(SA.sliver_info_mandatory_fields,
-                                                   SA.sliver_info_supplemental_fields), 
+                                                   SA.sliver_info_supplemental_fields),
         'update_sliver_info' : UpdateArgumentCheck(SA.sliver_info_mandatory_fields,
                                                    SA.sliver_info_supplemental_fields,
-                                                   {'sliver_urn' : "URN"}), 
+                                                   {'sliver_urn' : "URN"}),
         'delete_sliver_info' : SimpleArgumentCheck({'sliver_urn' : 'URN'}),
         'lookup_sliver_info' : LookupArgumentCheckMatchOptional(SA.sliver_info_mandatory_fields,
-                                                                SA.sliver_info_supplemental_fields), 
-        
+                                                                SA.sliver_info_supplemental_fields),
+
         # Argument checks for project request methods
         # No options required (context_type, request_id, resolution_status, resolution_description arguments)
-        'create_request' :  None, 
+        'create_request' :  None,
         # No options required (context_type, request_id, resolution_status, resolution_description arguments)
-        'resolve_pending_request' :  None, 
+        'resolve_pending_request' :  None,
         # No options required (context_type, context_id, status arguments)
         'get_requests_for_context' :  None,
         # No options required (member_id, context_type, context_id, status arguments)
@@ -117,7 +117,7 @@ class SAv1Guard(ABACGuardBase):
         'accept_invitation' : None
 
         }
-    
+
 
     # Set of invocation checks indexed by method name
     INVOCATION_CHECK_FOR_METHOD = None
@@ -157,10 +157,3 @@ class SAv1Guard(ABACGuardBase):
         if self.ROW_CHECK_FOR_METHOD.has_key(method):
             return self.ROW_CHECK_FOR_METHOD[method]
         return None
-
-
-
-
-
-        
-    

--- a/plugins/sarm/SAv1Guard.py
+++ b/plugins/sarm/SAv1Guard.py
@@ -68,7 +68,7 @@ class SAv1Guard(ABACGuardBase):
         'modify_slice_membership' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
         'lookup_slice_members' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
         'lookup_slices_for_member' : SimpleArgumentCheck({'member_urn' : 'URN'}),
-        'get_credentials' : SimpleArgumentCheck({'slice_urn' : 'URN'}),
+        'get_credentials' : SimpleArgumentCheck({'urn' : 'URN'}),
 
         # Argument checks for project methods
 

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -412,7 +412,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         <privileges>
             <privilege>
                 <name>@project_privilege@</name>
-                <can_delegate>true</can_delegate>
+                <can_delegate>false</can_delegate>
             </privilege>
         </privileges>
     </credential>

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -469,7 +469,9 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         # We have no project certificates, leave this blank
         project_certificate = ''
         # TODO: 24 hours from now in UTC
-        expiration = ''
+        expiration = datetime.datetime.utcnow()
+        expiration = expiration + datetime.timedelta(hours=24)
+        expiration = expiration.strftime(STANDARD_DATETIME_FORMAT)
         # TODO: How to determine privilege and convert to credential value?
         privilege = ''
         substitutions = dict(serial=serial,

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -332,20 +332,6 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         return result
 
-    def get_credentials(self, client_cert, urn, credentials, options,
-                        session):
-        (authority, typ, name) = parse_urn(urn)
-        if typ == 'slice':
-            return self.get_slice_credentials(client_cert, urn, credentials,
-                                              options, session)
-        elif typ == 'project':
-            return self.get_project_credentials(client_cert, urn, credentials,
-                                                options, session)
-        else:
-            # Unknown URN type, so fail.
-            msg = 'Invalid URN type "%s" in get_credentials' % (typ)
-            raise CHAPIv1ArgumentError(msg)
-
     def get_slice_credentials(self, client_cert, slice_urn, credentials, options,
                               session):
 
@@ -408,8 +394,14 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         return result
 
-    def get_project_credentials(self, client_cert, slice_urn, credentials,
+    def get_project_credentials(self, client_cert, project_urn, credentials,
                                 options, session):
+        # Look up project
+        # Gather info for credential
+        # Do string replacement into credential template
+        # Create credential structure (see get_slice_credentials)
+        # Do we need to return an ABAC credential?
+        # Return project credentials
         msg = 'get_project_credentials is not implemented yet.'
         raise CHAPIv1NotImplementedError(msg)
 

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -81,6 +81,9 @@ class MemberRole(object):
 # Implementation of SA that speaks to GPO Slice and projects table schema
 class SAv1PersistentImplementation(SAv1DelegateBase):
 
+    PROJECT_CREDENTIAL_TEMPLATE = \
+            "/usr/share/geni-chapi/project_credential.xml"
+
     def __init__(self):
         super(SAv1PersistentImplementation, self).__init__()
         self.db = pm.getService('chdbengine')
@@ -99,6 +102,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         self.trusted_root = self.config.get('chapiv1rpc.ch_cert_root')
         self.authority = self.config.get('chrm.authority')
+        self.project_cred_tmpl = self.PROJECT_CREDENTIAL_TEMPLATE
 
         self.trusted_root_files = \
             [os.path.join(self.trusted_root, f) \
@@ -398,51 +402,6 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         return result
 
-    project_cred = '''<?xml version="1.0" encoding="utf-8"?>
-    <signed-credential xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.planet-lab.org/resources/sfa/credential.xsd" xsi:schemaLocation="http://www.planet-lab.org/resources/sfa/ext/policy/1 http://www.planet-lab.org/resources/sfa/ext/policy/1/policy.xsd">
-    <credential xml:id="ref0">
-        <type>privilege</type>
-        <serial>@serial@</serial>
-        <owner_gid>@owner_certificate@</owner_gid>
-        <owner_urn>@owner_urn@</owner_urn>
-        <target_gid>@project_certificate@</target_gid>
-        <target_urn>@project_urn@</target_urn>
-        <uuid/>
-        <expires>@expiration@</expires>
-        <privileges>
-            <privilege>
-                <name>@project_privilege@</name>
-                <can_delegate>false</can_delegate>
-            </privilege>
-        </privileges>
-    </credential>
-    <signatures>
-        <Signature xmlns="http://www.w3.org/2000/09/xmldsig#" xml:id="Sig_ref0">
-        <SignedInfo>
-            <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-            <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
-            <Reference URI="#ref0">
-                <Transforms>
-                    <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-                </Transforms>
-                <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-                <DigestValue/>
-            </Reference>
-        </SignedInfo>
-        <SignatureValue/>
-        <KeyInfo>
-            <X509Data>
-                <X509SubjectName/>
-                <X509IssuerSerial/>
-                <X509Certificate/>
-            </X509Data>
-            <KeyValue/>
-        </KeyInfo>
-    </Signature>
-    </signatures>
-    </signed-credential>
-    '''
-
     def project_cred_privilege_for_role(self, role):
         """Leads and Admins get 'pi' privilege in a project credential.
         Members get 'user' privilege in a project credential.
@@ -510,7 +469,10 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
             '@expiration@': expiration,
             '@project_privilege@': privilege
         }
-        signed_cred = self.sign_credential(self.project_cred, substitutions,
+        # Read the project credential template
+        with open(self.project_cred_tmpl, 'r') as pcfile:
+            project_cred = pcfile.read()
+        signed_cred = self.sign_credential(project_cred, substitutions,
                                            self.cert, self.key)
         raw_result = [dict(geni_type='geni_sfa',
                            geni_version='3',

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -425,13 +425,11 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
     def get_project_credentials(self, client_cert, project_urn, credentials,
                                 options, session):
+        """Generate a project credential for the calling user. Only
+        an SFA-style credential is generated. No ABAC credential is
+        generated.
+        """
         (authority, typ, project_name) = parse_urn(project_urn)
-        # Look up project
-        # Gather info for credential
-        # Do string replacement into credential template
-        # Create credential structure (see get_slice_credentials)
-        # Do we need to return an ABAC credential?
-        # Return project credentials
         q = session.query(self.db.PROJECT_TABLE.c.project_id)
         q = q.filter(self.db.PROJECT_TABLE.c.project_name == project_name)
         q = q.filter(self.db.PROJECT_TABLE.c.expired == 'f')
@@ -441,7 +439,6 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                    " or non-existent project %s")
             raise CHAPIv1ArgumentError(msg % project_urn)
         row = rows[0]
-        # We don't use or need to use this value...
         project_id = row.project_id
         # Ignore the credential serial number
         serial = ''
@@ -452,11 +449,11 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         user_urn = get_urn_from_cert(client_cert)
         # We have no project certificates, leave this blank
         project_certificate = ''
-        # TODO: 24 hours from now in UTC
+        # 24 hours from now in UTC
         expiration = datetime.datetime.utcnow()
         expiration = expiration + datetime.timedelta(hours=24)
         expiration = expiration.strftime(STANDARD_DATETIME_FORMAT)
-        # TODO: How to determine privilege and convert to credential value?
+        # Determine project role and convert to credential privilege value
         member_id = self.get_member_id_for_urn(session, user_urn)
         role = self.get_project_role(session, project_id, member_id)
         privilege = self.project_cred_privilege_for_role(role)

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -51,6 +51,7 @@ from tools.ABACManager import *
 from tools.cs_utils import *
 from tools.chapi_log import *
 from tools.chapi_utils import *
+from tools.credential_tools import generate_credential
 
 # classes for mapping to sql tables
 
@@ -470,19 +471,13 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         # Read the project credential template
         with open(self.project_cred_tmpl, 'r') as pcfile:
             project_cred = pcfile.read()
-        signed_cred = self.sign_credential(project_cred, substitutions,
-                                           self.cert, self.key)
+        signed_cred = generate_credential(project_cred, substitutions,
+                                          self.cert, self.key)
         raw_result = [dict(geni_type='geni_sfa',
                            geni_version='3',
                            geni_value=signed_cred)]
         result = self._successReturn(raw_result)
         return result
-
-    def sign_credential(self, template, substitutions, sign_cert_file,
-                        sign_key_file):
-        for k,v in substitutions.iteritems():
-            template = template.replace(k, v)
-        return template
 
     # check whether a current slice exists, and if so return its id
     def get_slice_id(self, session, field, value, include_expired=False):

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -119,11 +119,11 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         serverURL = envService.getServerURL()
         api_versions = {chapi.Parameters.VERSION_NUMBER : serverURL}
         implementation_info = get_implementation_info(SA_LOG_PREFIX)
-        version_info = {"VERSION" : chapi.Parameters.VERSION_NUMBER, 
+        version_info = {"VERSION" : chapi.Parameters.VERSION_NUMBER,
                         "URN " : self.urn,
                         "IMPLEMENTATION" : implementation_info,
                         "SERVICES" : SA.services,
-                        "CREDENTIAL_TYPES" : SA.credential_types, 
+                        "CREDENTIAL_TYPES" : SA.credential_types,
                         "ROLES" : attribute_type_names.values(),
                         "API_VERSIONS" : api_versions,
                         "FIELDS": SA.supplemental_fields}
@@ -195,7 +195,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
     def update_slice_expirations(self, client_uuid, session):
         self.update_expirations(client_uuid, 'slice', False, session)
 
-    # Check for 
+    # Check for
     #   Recently expired projects and set their expired flags to 't'
     #   Recently extended expired projects and set their expired flags to 'f'
     def update_project_expirations(self, client_uuid, session):
@@ -245,7 +245,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         return result
 
     # members in a slice
-    def lookup_slice_members(self, client_cert, slice_urn, 
+    def lookup_slice_members(self, client_cert, slice_urn,
                              credentials, options, session):
         slice_id = None
         if "match" in options:
@@ -264,8 +264,8 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
             else:
                 raise CHAPIv1ArgumentError("Unknown slice %s - cannot lookup members" % slice_urn)
 
-        result = self.lookup_members(client_cert, self.db.SLICE_TABLE, 
-                                     self.db.SLICE_MEMBER_TABLE, slice_urn, "slice_urn", 
+        result = self.lookup_members(client_cert, self.db.SLICE_TABLE,
+                                     self.db.SLICE_MEMBER_TABLE, slice_urn, "slice_urn",
                                      "slice_id", "SLICE_ROLE", "SLICE_MEMBER", "SLICE_MEMBER_UID",
                                      slice_id, session)
 
@@ -277,9 +277,9 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                                credentials, options, session):
 
         project_name = from_project_urn(project_urn)
-        result = self.lookup_members(client_cert, self.db.PROJECT_TABLE, 
-                                     self.db.PROJECT_MEMBER_TABLE, project_name, "project_name", 
-                                     "project_id", "PROJECT_ROLE", "PROJECT_MEMBER", 
+        result = self.lookup_members(client_cert, self.db.PROJECT_TABLE,
+                                     self.db.PROJECT_MEMBER_TABLE, project_name, "project_name",
+                                     "project_id", "PROJECT_ROLE", "PROJECT_MEMBER",
                                      "PROJECT_MEMBER_UID", None, session)
 
         return result
@@ -288,7 +288,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
     # shared code for lookup_slice_members() and lookup_project_members()
     def lookup_members(self, client_cert, table, member_table, \
                            name, name_field, \
-                           id_field, role_txt, member_txt, member_uid_txt, 
+                           id_field, role_txt, member_txt, member_uid_txt,
                        id_value, session):
 
         client_uuid = get_uuid_from_cert(client_cert)
@@ -317,10 +317,10 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         client_uuid = get_uuid_from_cert(client_cert)
         self.update_slice_expirations(client_uuid, session)
 
-        rows = self.lookup_for_member(member_urn, self.db.SLICE_TABLE, 
-                                      self.db.SLICE_MEMBER_TABLE, 
+        rows = self.lookup_for_member(member_urn, self.db.SLICE_TABLE,
+                                      self.db.SLICE_MEMBER_TABLE,
                                       SA.slice_field_mapping,
-                                      "slice_urn", "slice_id", 
+                                      "slice_urn", "slice_id",
                                       options, session)
         slices = [{"SLICE_ROLE" : row.name, \
                        "SLICE_UID" : row.slice_id, \
@@ -332,7 +332,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         return result
 
-    def get_credentials(self, client_cert, slice_urn, credentials, options, 
+    def get_credentials(self, client_cert, slice_urn, credentials, options,
                         session):
 
         client_uuid = get_uuid_from_cert(client_cert)
@@ -347,7 +347,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
             raise CHAPIv1ArgumentError("Can't get slice credential " + \
                                            "on expired or non-existent slice %s"\
                                            % slice_urn)
-        
+
         row = rows[0]
         expiration = row.expiration
         # Temporary fix, see ticket #84.
@@ -376,10 +376,10 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
             role_name = attribute_type_names[row.role]
             slice_role_assertion = "ME.IS_%s_%s<-CALLER" % (role_name, flatten_urn(slice_urn))
 #            print "SRA = " + slice_role_assertion
-            slice_role_credential = generate_abac_credential(slice_role_assertion, 
-                                                              self.cert, self.key, 
+            slice_role_credential = generate_abac_credential(slice_role_assertion,
+                                                              self.cert, self.key,
                                                               {"CALLER" : client_cert})
-                                                              
+
             abac_raw_creds.append(slice_role_credential)
 
         sfa_creds = \
@@ -406,7 +406,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
     def get_slice_ids(self, session, field, value, include_expired=False):
         q = session.query(Slice.slice_id)
         # *** MSB 2-24-2014
-        # *** We are adding this for now to disallow creating 
+        # *** We are adding this for now to disallow creating
         # *** slices that differ only by case. If case insensitivity
         # *** is the decided semantics, we need to make changes in lookup
         # *** and other methods as well
@@ -429,7 +429,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
     def get_project_id(self, session, field, value):
         q = session.query(Project.project_id)
         # *** MSB 2-24-2014
-        # *** We are adding this for now to disallow creating 
+        # *** We are adding this for now to disallow creating
         # *** projects that differ only by case. If case insensitivity
         # *** is the decided semantics, we need to make changes in lookup
         # *** and other methods as well
@@ -479,7 +479,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 #            options['fields']['_GENI_SLICE_EMAIL'] = \
 #                'slice-%s@example.com' % name
 
-        # If a slice email is provided, use it. 
+        # If a slice email is provided, use it.
 #        options['fields']['_GENI_SLICE_EMAIL'] = None
 
         # fill in the fields of the object
@@ -513,13 +513,13 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         project_expiration = project_info.expiration
         if project_info.expired:
             raise CHAPIv1ArgumentError("May not create a slice on expired project %s" % project_urn);
-        
+
         # Check that slice name is valid
         if ' ' in name:
             raise CHAPIv1ArgumentError('Slice name may not contain spaces.')
         elif len(name) > 19: # FIXME: Externalize this
             raise CHAPIv1ArgumentError('Slice name %s is too long - use at most 19 characters.' %name)
-            
+
         # FIXME: Externalize this
         pattern = '^[a-zA-Z0-9][a-zA-Z0-9-]{0,18}$'
         valid = re.match(pattern,name)
@@ -583,7 +583,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         leadMember.slice_id = slice.slice_id
         leadMember.member_id = client_uuid
         leadMember.role = LEAD_ATTRIBUTE
-#        ins = self.db.SLICE_MEMBER_TABLE.insert().values(slice_id=slice.slice_id, member_id = client_uuid, role = LEAD_ATTRIBUTE) 
+#        ins = self.db.SLICE_MEMBER_TABLE.insert().values(slice_id=slice.slice_id, member_id = client_uuid, role = LEAD_ATTRIBUTE)
 #        result = session.execute(ins)
         session.add(leadMember)
 
@@ -605,7 +605,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         # Log the slice create event
         attribs = {"SLICE" : slice.slice_id, "PROJECT" : slice.project_id}
         log_options = self.subcall_options(options)
-        self.logging_service.log_event("Created slice " + name, 
+        self.logging_service.log_event("Created slice " + name,
                                        attribs, credentials, log_options,
                                        session=session)
         chapi_audit_and_log(SA_LOG_PREFIX, "Created slice " + name + " in project " + slice.project_id, logging.INFO, {'user': user_email})
@@ -622,7 +622,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         slice_uuid = \
             self.get_slice_id(session, 'slice_urn', slice_urn) # MIK: only non-expired slices
-        if not slice_uuid: 
+        if not slice_uuid:
             raise CHAPIv1ArgumentError('No slice with urn ' + slice_urn)
         updates = {}
 
@@ -697,11 +697,11 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                     # re-use it when re-generating the slice certifate
                     # updates['key'] = k.save_to_string()
                     updates['certificate'] = cert.save_to_string()
-                    chapi_warn(SA_LOG_PREFIX, 
+                    chapi_warn(SA_LOG_PREFIX,
                                "Re-generated certificate for slice %s to last past new expiration %s" % (slice_urn,
-                                                                                                         new_exp.isoformat()), 
+                                                                                                         new_exp.isoformat()),
                                {'user': user_email})
-                    
+
             updates[SA.slice_field_mapping[field]] = value
 
         q = q.update(updates)
@@ -710,14 +710,14 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         client_uuid = get_uuid_from_cert(client_cert)
         attribs = {"PROJECT" : project_uuid, "SLICE" : slice_uuid}
         log_options = self.subcall_options(options)
-        if "SLICE_EXPIRATION" in options['fields']: 
+        if "SLICE_EXPIRATION" in options['fields']:
             # FIXME: Format in RFC3339 format not iso
             self.logging_service.log_event("Renewed slice %s until %s" % \
                                                (slice_name, new_exp.isoformat()), \
                                                attribs, credentials, log_options,
                                            session=session)
         else:
-            self.logging_service.log_event("Updated slice " + slice_name, 
+            self.logging_service.log_event("Updated slice " + slice_name,
                                            attribs, credentials, log_options,
                                            session=session)
 
@@ -755,7 +755,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                    + ' characters or hyphen or underscore. No leading hyphen'
                    + ' or underscore.')
             raise CHAPIv1ArgumentError(msg % (name))
-        
+
         # check that project does not already exist
         if self.get_project_id(session, "project_name", name):
             raise CHAPIv1DuplicateError('There already exists a project named ' + name)
@@ -796,11 +796,11 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 #        ins = self.db.PROJECT_MEMBER_TABLE.insert().values(\
 #            project_id=project.project_id, \
 #                member_id = client_uuid, \
-#                role = LEAD_ATTRIBUTE) 
+#                role = LEAD_ATTRIBUTE)
 #        result = session.execute(ins)
 
         # get name of project lead
-        ma_options = {'match' : {'MEMBER_UID' : project.lead_id },'filter': ['_GENI_MEMBER_DISPLAYNAME','MEMBER_FIRSTNAME','MEMBER_LASTNAME','MEMBER_EMAIL']}  
+        ma_options = {'match' : {'MEMBER_UID' : project.lead_id },'filter': ['_GENI_MEMBER_DISPLAYNAME','MEMBER_FIRSTNAME','MEMBER_LASTNAME','MEMBER_EMAIL']}
         member_info = self._ma_handler._delegate.lookup_identifying_member_info(client_cert,credentials,ma_options, session)
         leadname = ""
         info = member_info['value']
@@ -810,7 +810,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         log_options = self.subcall_options(options)
         attribs = {"PROJECT" : project.project_id, "MEMBER" : project.lead_id}
-        self.logging_service.log_event("Created project " + name + " with lead " + leadname, 
+        self.logging_service.log_event("Created project " + name + " with lead " + leadname,
                                        attribs, credentials, log_options,
                                        session=session)
         chapi_audit_and_log(SA_LOG_PREFIX, "Created project " + name + " with lead " + leadname, logging.INFO, {'user': user_email})
@@ -880,7 +880,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         attribs = {"PROJECT" : project_uuid}
 
         log_options = self.subcall_options(options)
-        self.logging_service.log_event("Updated project " + name + change, 
+        self.logging_service.log_event("Updated project " + name + change,
                                        attribs, credentials, log_options,
                                        session=session)
 
@@ -932,10 +932,10 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         client_uuid = get_uuid_from_cert(client_cert)
         self.update_project_expirations(client_uuid, session)
 
-        rows = self.lookup_for_member(member_urn, self.db.PROJECT_TABLE, 
-                                      self.db.PROJECT_MEMBER_TABLE, 
-                                      SA.project_field_mapping, 
-                                      "project_name", "project_id", 
+        rows = self.lookup_for_member(member_urn, self.db.PROJECT_TABLE,
+                                      self.db.PROJECT_MEMBER_TABLE,
+                                      SA.project_field_mapping,
+                                      "project_name", "project_id",
                                       options, session)
         projects = [{"PROJECT_ROLE" : row.name,
                      "PROJECT_UID" : row.project_id,
@@ -947,7 +947,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         return result
 
     # shared code between projects and slices
-    def lookup_for_member(self, member_urn, table, member_table, 
+    def lookup_for_member(self, member_urn, table, member_table,
                           field_mapping,
                           name_field, id_field, options, session):
         q = session.query(member_table, self.db.MEMBER_ATTRIBUTE_TABLE,
@@ -1010,7 +1010,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                                 continue
                             new_project_lead = row['PROJECT_MEMBER_UID']
                             new_lead_urn = self.get_member_urn_for_id(session, new_project_lead)
-                            
+
                             role_options = {'members_to_change': [{'PROJECT_MEMBER': old_lead_urn, 'PROJECT_ROLE': 'MEMBER'},{'PROJECT_MEMBER': new_lead_urn, 'PROJECT_ROLE': 'LEAD'}]}
                             role_options.update(speaking_for)
                             result = self.modify_membership(client_cert, session, ProjectMember, client_uuid, \
@@ -1024,7 +1024,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                         raise CHAPIv1ArgumentError(('Cannot remove %s lead %s: ' +
                                                     'No project admins are authorized to be a project lead') %
                                                    (project_urn, old_lead_urn))
-                    
+
         if 'members_to_change' in options:
             # if project lead will change, make sure new project lead authorized
             for change in options['members_to_change']:
@@ -1067,7 +1067,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         q = q.filter(self.db.SLICE_TABLE.c.project_id == project_id)
         q = q.filter(self.db.SLICE_TABLE.c.expired == False) # We only care about active slices
         project_slices = q.all()
-    
+
         slice_uids = [row.slice_id for row in project_slices]
         slice_urns = {}
         for row in project_slices:
@@ -1083,7 +1083,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
             chapi_audit_and_log(SA_LOG_PREFIX, "Changed lead for project %s from %s to %s" % (name, old_lead_urn, project_lead_urn), logging.INFO, {'user': user_email})
             # FIXME: Add call to log service? It would be a duplicate of sorts
 
- 
+
         # make new project lead admin on slices
             opt = [{'SLICE_MEMBER': project_lead_urn, 'SLICE_ROLE': 'ADMIN'}]
             result3 = self.lookup_slices_for_member(client_cert, \
@@ -1101,7 +1101,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                     self.modify_membership(client_cert, session, SliceMember, client_uuid, \
                            slice['SLICE_UID'], slice['SLICE_URN'], credentials, lead_options, \
                            'slice_id', 'SLICE_MEMBER', 'SLICE_ROLE', 'slice')
-                    
+
             # add lead to slices not yet a member of
             for slice_id, slice_urn in slice_urns.iteritems():
                  lead_options2 = {'members_to_add': opt}
@@ -1223,7 +1223,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                                           credentials, options, 'slice_id', \
                                           'SLICE_MEMBER', 'SLICE_ROLE', \
                                           'slice')
-        
+
         # Validate that new slice lead is not a project auditor
         new_slice_lead = self.get_slice_lead(session,slice_id)
         new_lead_urn = self.get_member_urn_for_id(session, new_slice_lead)
@@ -1232,10 +1232,10 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         q = q.filter(Slice.slice_id == slice_id)
         slice_row = q.one()
 
-        rows = self.lookup_for_member(new_lead_urn, self.db.PROJECT_TABLE, 
-                                      self.db.PROJECT_MEMBER_TABLE, 
+        rows = self.lookup_for_member(new_lead_urn, self.db.PROJECT_TABLE,
+                                      self.db.PROJECT_MEMBER_TABLE,
                                       SA.project_field_mapping,
-                                      "project_name", "project_id", 
+                                      "project_name", "project_id",
                                       {}, session)
         projects = [{"PROJECT_ROLE" : row.name,
                      "PROJECT_UID" : row.project_id,
@@ -1250,18 +1250,18 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         if role == 'AUDITOR':
             raise CHAPIv1ArgumentError('Cannot make a project auditor a slice lead')
-        
+
         # if slice lead has changed, change in sa_slice table
         if new_slice_lead != old_slice_lead:
             q = session.query(Slice)
             q = q.filter(Slice.slice_id == slice_id)
             q = q.update({"owner_id" : new_slice_lead})
-            
+
 
         return result
 
     # shared between modify_slice_membership and modify_project_membership
-    def modify_membership(self, client_cert, session, member_class, client_uuid, id, urn, 
+    def modify_membership(self, client_cert, session, member_class, client_uuid, id, urn,
                           credentials, options, id_field,
                           member_str, role_str, text_str):
 
@@ -1270,25 +1270,25 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         # Grab the display names and IDs for all members whose membership we are changing
         all_urns = []
-        if 'members_to_add' in options: 
+        if 'members_to_add' in options:
             for member_to_add in options['members_to_add']:
                 all_urns.append(member_to_add[member_str])
-        if 'members_to_remove' in options: 
+        if 'members_to_remove' in options:
             for member_to_remove in options['members_to_remove']:
                 all_urns.append(member_to_remove)
-        if 'members_to_change' in options: 
+        if 'members_to_change' in options:
             for member_to_change in options['members_to_change']:
                 all_urns.append(member_to_change[member_str])
 #        chapi_info('SA', "ALL_URNS = %s" % all_urns)
 
-        # Only allow adding non-disabled members. 
+        # Only allow adding non-disabled members.
         # Log but ignore any attempt to do so.
         if 'members_to_add' in options:
             additions = options['members_to_add']
             members_to_add = [mem[member_str] for mem in additions]
             enabled, disabled = check_disabled_users(self.db, members_to_add, session)
             if len(disabled) > 0:
-                chapi_info(SA_LOG_PREFIX, 
+                chapi_info(SA_LOG_PREFIX,
                                    "Attempt to add disabled users %s" %
                                    disabled)
                 new_additions = [addition for addition in additions \
@@ -1301,8 +1301,8 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         all_urns.append(caller_urn)
 
         lookup_identifying_options = {\
-            "match" : {"MEMBER_URN" : all_urns}, 
-            "filter" : ["_GENI_MEMBER_DISPLAYNAME", "MEMBER_FIRSTNAME", 
+            "match" : {"MEMBER_URN" : all_urns},
+            "filter" : ["_GENI_MEMBER_DISPLAYNAME", "MEMBER_FIRSTNAME",
                         "MEMBER_LASTNAME", "MEMBER_EMAIL", "_GENI_IDENTIFYING_MEMBER_UID"]}
         ma_handler = pm.getService('mav1handler')
         result = ma_handler._delegate.lookup_identifying_member_info(client_cert, credentials, lookup_identifying_options, session)
@@ -1440,17 +1440,17 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                 if caller_urn == member_urn:
                     self.logging_service.log_event(
                         "%s accepted an invitation to join %s %s in role %s" % \
-                            (member_name, text_str, label, member_role), 
+                            (member_name, text_str, label, member_role),
                         attribs, credentials, log_options, session=session)
-                    chapi_audit_and_log(SA_LOG_PREFIX, 
+                    chapi_audit_and_log(SA_LOG_PREFIX,
                                         "%s accepted an invitation to join %s %s in role %s" % \
                                             (member_name, text_str, label2, member_role), logging.INFO, {'user': user_email})
                 else:
                     self.logging_service.log_event(
                         "%s Added member %s in role %s to %s %s" % \
-                            (caller_name, member_name, member_role, text_str, label), 
+                            (caller_name, member_name, member_role, text_str, label),
                         attribs, credentials, log_options, session=session)
-                    chapi_audit_and_log(SA_LOG_PREFIX, 
+                    chapi_audit_and_log(SA_LOG_PREFIX,
                                         "%s Added member %s in role %s to %s %s" % \
                                             (caller_name, member_name, member_role, text_str, label2), logging.INFO, {'user': user_email})
                 # Email system admins about new project members
@@ -1476,7 +1476,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                 log_options = self.subcall_options(options)
                 self.logging_service.log_event(
                     "Changed member %s to role %s in %s %s" % \
-                        (member_name, member_role, text_str, label), 
+                        (member_name, member_role, text_str, label),
                         attribs, credentials, log_options, session=session)
                 chapi_info(SA_LOG_PREFIX, "Changed member %s to role %s in %s %s" % (member_name, member_role, text_str, label2), {'user': user_email})
 
@@ -1549,7 +1549,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
             attrib_project_id = row.project_id
             attrib_name = row.name
             attrib_value = row.value
-            attrib = {'project_id' : attrib_project_id, 
+            attrib = {'project_id' : attrib_project_id,
                       'name' : attrib_name, 'value' : attrib_value}
             attribs.append(attrib)
         result = self._successReturn(attribs)
@@ -1570,7 +1570,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
     def expire_sliver_infos(self, session):
         # Delete expired sliver_info entries
         q = session.query(SliverInfo)
-        # Find all sliver info entries that expired x minutes ago 
+        # Find all sliver info entries that expired x minutes ago
         gracemin = 6 # FIXME: Externalize this
         q = q.filter(and_(SliverInfo.expiration != None, SliverInfo.expiration < text("now() at time zone 'utc' - INTERVAL '%d MINUTE'" % gracemin)))
         if q.count() > 0:
@@ -1600,7 +1600,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 #            sliver.creator_urn = get_urn_from_cert(client_cert)
 
         # If there is already a sliver_info record with the same sliver_urn,
-        # Then treat this as an update instead of a create. 
+        # Then treat this as an update instead of a create.
         # This might happen if the last sliver was recorded with no expiration time,
         # and the sliver_info was never explicitly deleted.
         # Note that sliver urns are unique over time per the spec,
@@ -1724,7 +1724,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                 status = PENDING_STATUS, \
                 requestor = client_uuid)
         result = session.execute(ins)
-        
+
         query = "select max(id) from pa_project_member_request"
         request_id  = session.execute(query).fetchone().values()[0]
         result = self._successReturn(request_id)
@@ -1744,11 +1744,11 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         status_info = q.one()
         if not status_info.status == PENDING_STATUS:
             raise CHAPIv1ArgumentError("Request %s is no longer pending" % str(request_id))
-        
-        update_values = {'status' : resolution_status, 
-                         'resolver' : client_uuid, 
+
+        update_values = {'status' : resolution_status,
+                         'resolver' : client_uuid,
                          'resolution_description' : resolution_description,
-                         'resolution_timestamp' : dt.datetime.utcnow() 
+                         'resolution_timestamp' : dt.datetime.utcnow()
                          }
         update = self.db.PROJECT_REQUEST_TABLE.update(values=update_values)
         update = update.where(self.db.PROJECT_REQUEST_TABLE.c.id == request_id)
@@ -1768,8 +1768,8 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         if status:
             q = q.filter(self.db.PROJECT_REQUEST_TABLE.c.status == status)
         rows = q.all()
-        result = [construct_result_row(row, SA.project_request_columns, 
-                                       SA.project_request_field_mapping, 
+        result = [construct_result_row(row, SA.project_request_columns,
+                                       SA.project_request_field_mapping,
                                        session) \
                       for row in rows]
         result = self._successReturn(result)
@@ -1790,7 +1790,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         rows = q.all()
 #        print "ROWS = " + str(rows)
-        result = [construct_result_row(row, SA.project_request_columns, 
+        result = [construct_result_row(row, SA.project_request_columns,
                                        SA.project_request_field_mapping,
                                        session) \
                       for row in rows]
@@ -1813,7 +1813,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         q = q.filter(self.db.PROJECT_REQUEST_TABLE.c.status == PENDING_STATUS)
         rows = q.all()
 #        print "ROWS = " + str(rows)
-        result = [construct_result_row(row, SA.project_request_columns, 
+        result = [construct_result_row(row, SA.project_request_columns,
                                        SA.project_request_field_mapping,
                                        session) \
                       for row in rows]
@@ -1828,7 +1828,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         requests = self.get_pending_requests_for_user(client_cert, member_id, \
                                                           context_type, context_id,  \
-                                                          credentials, 
+                                                          credentials,
                                                       options, session)
         if requests['code'] != NO_ERROR:
             return requests
@@ -1847,8 +1847,8 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         if len(rows) == 0:
             return self._successReturn(None)
         result = \
-            self._successReturn(construct_result_row(rows[0], 
-                                                     SA.project_request_columns, 
+            self._successReturn(construct_result_row(rows[0],
+                                                     SA.project_request_columns,
                                                      SA.project_request_field_mapping,
                                                      session))
 
@@ -1869,8 +1869,8 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         project_name = from_project_urn(project_urn)
         project_id = self.get_project_id(session, 'project_name', project_name)
 
-        ins = self.db.PROJECT_ATTRIBUTE_TABLE.insert().values(project_id = project_id, 
-                                                              name = attr_name, 
+        ins = self.db.PROJECT_ATTRIBUTE_TABLE.insert().values(project_id = project_id,
+                                                              name = attr_name,
                                                               value = attr_value)
 
         session.execute(ins)
@@ -1901,12 +1901,12 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         return self._successReturn(result)
 
     # Invite a member to join a project in a given role
-    def invite_member(self, client_cert, role, project_id, 
+    def invite_member(self, client_cert, role, project_id,
                       credentials, options, session):
 
         # Set expiration
-        # insert into PA_PROJECT_MEMBER_INVITATION 
-        #    (project_id, role, expiration) values 
+        # insert into PA_PROJECT_MEMBER_INVITATION
+        #    (project_id, role, expiration) values
         #    (project_id, role, expiration)
         # Extract and return invite_id
 
@@ -1928,7 +1928,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         self._expire_project_invitations(session)
 
-        # select project_id, role, expiration from 
+        # select project_id, role, expiration from
         # PA_PROJECT_MEMBER_INVITATION where invite_id = invite_id
         q = session.query(ProjectInvitation)
         q = q.filter(ProjectInvitation.invite_id == invite_id)
@@ -1947,7 +1947,7 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         # Add the member to the project
         options = {'members_to_add' : [
-                {"PROJECT_MEMBER" : member_urn, 
+                {"PROJECT_MEMBER" : member_urn,
                  "PROJECT_ROLE" : role_name}
                 ]}
         result = self.modify_project_membership(client_cert, project_urn, credentials, options, session)
@@ -1969,6 +1969,3 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
             chapi_info(SA_LOG_PREFIX, 'Expiring project invitation ID %s Project %s role %s' % \
                            (row.invite_id, row.project_id, row.role))
             session.delete(row)
-
-
-

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -332,8 +332,22 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         return result
 
-    def get_credentials(self, client_cert, slice_urn, credentials, options,
+    def get_credentials(self, client_cert, urn, credentials, options,
                         session):
+        (authority, typ, name) = parse_urn(urn)
+        if typ == 'slice':
+            return self.get_slice_credentials(client_cert, urn, credentials,
+                                              options, session)
+        elif typ == 'project':
+            return self.get_project_credentials(client_cert, urn, credentials,
+                                                options, session)
+        else:
+            # Unknown URN type, so fail.
+            msg = 'Invalid URN type "%s" in get_credentials' % (typ)
+            raise CHAPIv1ArgumentError(msg)
+
+    def get_slice_credentials(self, client_cert, slice_urn, credentials, options,
+                              session):
 
         client_uuid = get_uuid_from_cert(client_cert)
         self.update_slice_expirations(client_uuid, session)
@@ -394,6 +408,10 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
 
         return result
 
+    def get_project_credentials(self, client_cert, slice_urn, credentials,
+                                options, session):
+        msg = 'get_project_credentials is not implemented yet.'
+        raise CHAPIv1NotImplementedError(msg)
 
     # check whether a current slice exists, and if so return its id
     def get_slice_id(self, session, field, value, include_expired=False):

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -451,11 +451,17 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         """
         # do the role constants exist somewhere?
         # I don't like having the numbers 1, 2, and 3 below
-        privilege = None
-        if role.id == 1 or role.id == 2:
+
+        # Duck typing: If it has an id attribute, use it, regardless
+        # of what kind of thing it is.
+        if not hasattr(role, 'id'):
+            privilege = 'none'
+        elif role.id == 1 or role.id == 2:
             privilege = 'pi'
         elif role.id == 3:
             privilege = 'user'
+        else:
+            privilege = 'none'
         return privilege
 
     def get_project_credentials(self, client_cert, project_urn, credentials,

--- a/tools/SA_constants.py
+++ b/tools/SA_constants.py
@@ -104,11 +104,11 @@ slice_field_mapping = {
     "SLICE_EXPIRATION" :  "expiration",
     "SLICE_EXPIRED" :  "expired",
     "SLICE_CREATION" :  "creation",
-    "SLICE_PROJECT_URN" : {"base_field" : "project_id", 
+    "SLICE_PROJECT_URN" : {"base_field" : "project_id",
                            "to_external" : convert_project_uid_to_urn,
                            "to_internal" : convert_project_urn_to_uid},
     "_GENI_SLICE_EMAIL" : "slice_email",
-    "_GENI_SLICE_OWNER" : "owner_id", 
+    "_GENI_SLICE_OWNER" : "owner_id",
     "_GENI_PROJECT_UID": 'project_id'
 }
 
@@ -153,16 +153,16 @@ PROJECT_DEFAULT_INVITATION_EXPIRATION_HOURS = 72
 PROJECT_NAME_REGEX = '^[a-zA-Z][a-zA-Z0-9-_]{1,31}$'
 
 project_request_field_mapping = {
-    'id' : 'id', 
-    'context_type' : 'context_type', 
-    'context_id' : 'context_id', 
-    'request_text' : 'request_text', 
-    'request_type' : 'request_type', 
-    'request_details' : 'request_details', 
-    'requestor' : 'requestor', 
-    'status' : 'status', 
-    'creation_timestamp' : 'creation_timestamp', 
-    'resolver'  : 'resolver' , 
-    'resolution_timestamp' : 'resolution_timestamp', 
+    'id' : 'id',
+    'context_type' : 'context_type',
+    'context_id' : 'context_id',
+    'request_text' : 'request_text',
+    'request_type' : 'request_type',
+    'request_details' : 'request_details',
+    'requestor' : 'requestor',
+    'status' : 'status',
+    'creation_timestamp' : 'creation_timestamp',
+    'resolver'  : 'resolver' ,
+    'resolution_timestamp' : 'resolution_timestamp',
     'resolution_description' : 'resolution_description'
 }

--- a/tools/credential_tools.py
+++ b/tools/credential_tools.py
@@ -76,7 +76,7 @@ def generate_credential(template, mapping, signer_cert, signer_key):
     cert_chain = signer_cert_contents.split(CERT_END)
     cert_filenames = []
     for cert_element in cert_chain:
-        if not cert_element == 0:
+        if not cert_element:
             continue
         cert_file = tempfile.NamedTemporaryFile(delete=False)
         cert_filenames.append(cert_file.name)

--- a/tools/geni_utils.py
+++ b/tools/geni_utils.py
@@ -24,6 +24,7 @@
 # Utility functions for morphing from native schema to public-facing
 # schema
 
+import re
 import tools.pluginmanager as pm
 from datetime import datetime
 from cert_utils import *
@@ -47,6 +48,19 @@ def urn_for_slice(slice_name, project_name):
     authority = config.get("chrm.authority")
     return "urn:publicid:IDN+%s:%s+slice+%s" % \
         (authority, project_name, slice_name)
+
+
+def parse_urn(urn):
+    '''returns authority, type, name'''
+    m = re.search('urn:publicid:IDN\+([^\+]+)\+([^\+]+)\+([^\+]+)$', urn)
+    if m is not None:
+        return m.group(1), m.group(2), m.group(3)
+    else:
+        return None
+
+
+def make_urn(authority, typ, name):
+    return 'urn:publicid:IDN+'+authority+'+'+typ+'+'+name
 
 
 # Return the user display name

--- a/tools/geni_utils.py
+++ b/tools/geni_utils.py
@@ -48,7 +48,7 @@ def urn_for_slice(slice_name, project_name):
     return "urn:publicid:IDN+%s:%s+slice+%s" % \
         (authority, project_name, slice_name)
 
-    
+
 # Return the user display name
 # First, try '_GENI_MEMBER_DISPLAYNAME'
 # Then try 'MEMBER_FIRSTNAME' 'MEMBER_LASTNAME'
@@ -64,4 +64,3 @@ def get_member_display_name(member_identifying_info, member_urn):
         return member_identifying_info['MEMBER_EMAIL']
     else:
         return get_name_from_urn(member_urn)
-


### PR DESCRIPTION
Allow retrieval of project credentials via the get_credentials SA call. Leads and admins have "pi" privilege for compatibility with ProtoGENI's project credentials. Members have "user" privilege (again, see ProtoGENI). Operators will sometimes have "none" privilege because they can retrieve a credential, but are not members of the project.

Fixes #466
