### PR TITLE
Remove eval call from client.py

### DIFF
--- a/tools/client.py
+++ b/tools/client.py
@@ -32,7 +32,7 @@ from gcf.omnilib.frameworks.framework_base import Framework_Base
 from portal_client import *
 from geni_constants import *
 
-# Generic client to speak XMLRPC/SSL SA/CH/MA API calls to 
+# Generic client to speak XMLRPC/SSL SA/CH/MA API calls to
 
 class MAClientFramework(Framework_Base):
     def __init__(self, config, opts):
@@ -55,7 +55,7 @@ def parseOptions(args):
                           default=os.path.join(gcf_home, 'alice-key.pem'))
     parser.add_option("--cert", help="Location of user cert", \
                           default=os.path.join(gcf_home, 'alice-cert.pem'))
-    parser.add_option("--method", help="Name of method to invoke", 
+    parser.add_option("--method", help="Name of method to invoke",
                       default="get_version")
     parser.add_option("--page", help="Name of portal page to simulate (home, projects, slices)")
     parser.add_option("--eppn", help="EPPN of user")
@@ -97,7 +97,7 @@ def parseOptions(args):
             cred_file = cred_parts[0]
             cred_type = cred_parts[1]
             cred_data = open(cred_file).read()
-            cred_struct= {'geni_type' : cred_type, 'geni_version' : 1, 
+            cred_struct= {'geni_type' : cred_type, 'geni_version' : 1,
                           'geni_value' : cred_data}
             cred_structs.append(cred_struct)
         opts.credentials = cred_structs
@@ -114,7 +114,7 @@ def add_attribute(attributes, int_arg, uuid_arg):
         attributes['PROJECT'] = uuid_arg
     elif int_arg == SLICE_CONTEXT and uuid_arg:
         attributes['SLICE'] = uuid_arg
-        
+
 def main(args = sys.argv, do_print=True):
     logging.basicConfig()
     opts, args = parseOptions(args)
@@ -132,7 +132,7 @@ def main(args = sys.argv, do_print=True):
     config = {'cert' : opts.cert, 'key' : opts.key}
 
     framework = MAClientFramework(config, {})
-    client = framework.make_client(opts.url, opts.key, opts.cert, 
+    client = framework.make_client(opts.url, opts.key, opts.cert,
                                    allow_none=True,
                                    verbose=False)
     fcn = eval("client.%s" % opts.method)
@@ -237,37 +237,37 @@ def main(args = sys.argv, do_print=True):
                     opts.credentials, client_options)
     elif opts.method in ['create_sliver_info', 'lookup_sliver_info']:
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, 
+            _do_ssl(framework, suppress_errors, reason, fcn,
                     opts.credentials, client_options)
 
 
     # Project request methods
     elif opts.method in ['create_request']:
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg, 
+            _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg,
                     opts.uuid_arg, opts.int2_arg, opts.string_arg, opts.string2_arg, \
                         opts.credentials, client_options)
     elif opts.method in ['resolve_pending_request']:
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg, 
+            _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg,
                     opts.int2_arg, opts.int3_arg, opts.string_arg, \
                         opts.credentials, client_options)
     elif opts.method in ['invite_member']:
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg, 
-                    opts.uuid_arg, 
+            _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg,
+                    opts.uuid_arg,
                     opts.credentials, client_options)
-        
+
     elif opts.method in ['accept_invitation']:
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, 
+            _do_ssl(framework, suppress_errors, reason, fcn,
                     opts.uuid_arg, # invite_id
                     opts.uuid2_arg, # member_id
                     opts.credentials, client_options)
-        
+
     elif opts.method in ['get_requests_for_context']:
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg, 
+            _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg,
                     opts.uuid_arg, opts.int2_arg, opts.credentials, client_options)
     elif opts.method in ['get_requests_by_user']:
         (result, msg) = \
@@ -280,7 +280,7 @@ def main(args = sys.argv, do_print=True):
 
     elif opts.method in ['get_request_by_id']:
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, 
+            _do_ssl(framework, suppress_errors, reason, fcn,
                     opts.int_arg, opts.int2_arg, opts.credentials, client_options)
 
     # MA certificate methods
@@ -317,16 +317,16 @@ def main(args = sys.argv, do_print=True):
 
         # If the user entered an UUID
         if opts.uuid_arg:
- 
-            # Uptade the client options dictionary with the entered UUID  
-	    client_options["match"].update({"MEMBER_UID":opts.uuid_arg}) 
+
+            # Uptade the client options dictionary with the entered UUID
+	    client_options["match"].update({"MEMBER_UID":opts.uuid_arg})
 
 	# If the user entered an URN
         if opts.urn:
 
             # Uptade the client options dictionary with the entered URN
-	    client_options["match"].update({"MEMBER_URN":opts.urn}) 
- 
+	    client_options["match"].update({"MEMBER_URN":opts.urn})
+
 
       	# Send query message and retrieve the result and response message
 	(result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
@@ -347,7 +347,7 @@ def main(args = sys.argv, do_print=True):
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.urn, \
                         opts.credentials, options)
-        
+
 
     # Generic Federation v2 API methods
     elif opts.method in ['lookup', 'create']:
@@ -380,8 +380,8 @@ def main(args = sys.argv, do_print=True):
                                     client_attributes, \
                                     opts.credentials, client_options)
 
-    
-                             
+
+
     # Methods that take credentials and options and urn arguments
     elif opts.urn:
         (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
@@ -396,6 +396,6 @@ def main(args = sys.argv, do_print=True):
         print "RESULT = " + str(result)
         if msg:
             print "MSG = " + str(msg)
-    
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/tools/client.py
+++ b/tools/client.py
@@ -62,33 +62,43 @@ def parseOptions(args):
                       default=os.path.join(gcf_home, 'alice-cert.pem'))
     parser.add_option("--method", help="Name of method to invoke",
                       default="get_version")
-    parser.add_option("--page",
-                      help="Name of portal page to simulate (home, projects, slices)")
+    helpMsg = 'Name of portal page to simulate (home, projects, slices)'
+    parser.add_option("--page", help=helpMsg)
     parser.add_option("--eppn", help="EPPN of user")
     parser.add_option("--agg_url", help="URL of aggregate in some API calls",
                       default=None)
     parser.add_option("--string_arg", help="String argument for some calls",
                       default=None)
-    parser.add_option("--string2_arg", help="second string argument for some calls",
+    parser.add_option("--string2_arg",
+                      help="second string argument for some calls",
                       default=None)
     parser.add_option("--int_arg", help="Integer argument for some calls",
                       type='int', default=None)
-    parser.add_option("--int2_arg", help="second integer argument for some calls",
+    parser.add_option("--int2_arg",
+                      help="second integer argument for some calls",
                       type='int', default=None)
-    parser.add_option("--int3_arg", help="third integer argument for some calls",
+    parser.add_option("--int3_arg",
+                      help="third integer argument for some calls",
                       type='int', default=None)
     parser.add_option("--uuid_arg", help="UUID argument for some calls",
                       default=None)
-    parser.add_option("--uuid2_arg", help="second UUID argument for some calls",
+    parser.add_option("--uuid2_arg",
+                      help="second UUID argument for some calls",
                       default=None)
     parser.add_option("--uuid3_arg", help="third UUID argument for some calls",
                       default=None)
     parser.add_option("--file_arg", help="FILE argument for some calls",
                       default=None)
-    parser.add_option("--options", help="JSON of options argument", default="{}")
-    parser.add_option("--options_file", help="File containing JSON of options argument", default=None)
-    parser.add_option("--attributes", help="JSON of attributes argument", default="{}")
-    parser.add_option("--attributes_file", help="File containing JSON of attributes argument", default=None)
+    parser.add_option("--options", help="JSON of options argument",
+                      default="{}")
+    parser.add_option("--options_file",
+                      help="File containing JSON of options argument",
+                      default=None)
+    parser.add_option("--attributes", help="JSON of attributes argument",
+                      default="{}")
+    parser.add_option("--attributes_file",
+                      help="File containing JSON of attributes argument",
+                      default=None)
     parser.add_option("--credentials",
                       help="List of comma-separated credential files",
                       default="")
@@ -162,7 +172,8 @@ def main(args=sys.argv, do_print=True):
         (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
                                 client_options)
     # Methods that take a URN and an aggregate URL argument
-    elif opts.method in ['register_aggregate', 'remove_aggregate'] and opts.agg_url:
+    elif opts.method in ['register_aggregate', 'remove_aggregate'] and \
+            opts.agg_url:
         (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
                                 opts.urn, opts.agg_url, opts.credentials,
                                 client_options)
@@ -281,20 +292,25 @@ def main(args=sys.argv, do_print=True):
     elif opts.method in ['get_requests_for_context']:
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg,
-                    opts.uuid_arg, opts.int2_arg, opts.credentials, client_options)
+                    opts.uuid_arg, opts.int2_arg, opts.credentials,
+                    client_options)
     elif opts.method in ['get_requests_by_user']:
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.uuid_arg,
-                    opts.int_arg, opts.uuid2_arg, opts.int2_arg, opts.credentials, client_options)
-    elif opts.method in ['get_pending_requests_for_user', 'get_number_of_pending_requests_for_user']:
+                    opts.int_arg, opts.uuid2_arg, opts.int2_arg,
+                    opts.credentials, client_options)
+    elif opts.method in ['get_pending_requests_for_user',
+                         'get_number_of_pending_requests_for_user']:
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.uuid_arg,
-                    opts.int_arg, opts.uuid2_arg, opts.credentials, client_options)
+                    opts.int_arg, opts.uuid2_arg, opts.credentials,
+                    client_options)
 
     elif opts.method in ['get_request_by_id']:
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn,
-                    opts.int_arg, opts.int2_arg, opts.credentials, client_options)
+                    opts.int_arg, opts.int2_arg, opts.credentials,
+                    client_options)
 
     # MA certificate methods
     elif opts.method in ['create_certificate']:

--- a/tools/client.py
+++ b/tools/client.py
@@ -135,7 +135,7 @@ def main(args = sys.argv, do_print=True):
     client = framework.make_client(opts.url, opts.key, opts.cert,
                                    allow_none=True,
                                    verbose=False)
-    fcn = eval("client.%s" % opts.method)
+    fcn = getattr(client, opts.method)
     
     # Methods that take no arguments
     result = None

--- a/tools/client.py
+++ b/tools/client.py
@@ -136,7 +136,7 @@ def main(args = sys.argv, do_print=True):
                                    allow_none=True,
                                    verbose=False)
     fcn = getattr(client, opts.method)
-    
+
     # Methods that take no arguments
     result = None
     msg = None
@@ -301,37 +301,33 @@ def main(args = sys.argv, do_print=True):
         options = {}
 
 
-      	# Send query message and retrieve the result and response message
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-			attributes, opts.credentials, options)
+        # Send query message and retrieve the result and response message
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                attributes, opts.credentials, options)
 
     # Method to lookup for members
-    elif opts.method in ['lookup_public_member_info',\
-				'lookup_private_member_info',\
-				'lookup_allowed_member_info',\
-				'lookup_identifying_member_info'] and \
-				(opts.urn or opts.uuid_arg):
+    elif opts.method in ['lookup_public_member_info',
+                         'lookup_private_member_info',
+                         'lookup_allowed_member_info',
+                         'lookup_identifying_member_info'] and \
+            (opts.urn or opts.uuid_arg):
 
-	# Create client options dictionary
-	client_options = {"match":{}}
+        # Create client options dictionary
+        client_options = {"match": {}}
 
         # If the user entered an UUID
         if opts.uuid_arg:
-
             # Uptade the client options dictionary with the entered UUID
-	    client_options["match"].update({"MEMBER_UID":opts.uuid_arg})
+            client_options["match"].update({"MEMBER_UID": opts.uuid_arg})
 
-	# If the user entered an URN
+        # If the user entered an URN
         if opts.urn:
-
             # Uptade the client options dictionary with the entered URN
-	    client_options["match"].update({"MEMBER_URN":opts.urn})
+            client_options["match"].update({"MEMBER_URN": opts.urn})
 
-
-      	# Send query message and retrieve the result and response message
-	(result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    opts.credentials, client_options)
-
+        # Send query message and retrieve the result and response message
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                opts.credentials, client_options)
 
     # MA add/revoke privilege methods
     elif opts.method in ['add_member_privilege', 'revoke_member_privilege']:

--- a/tools/client.py
+++ b/tools/client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-#----------------------------------------------------------------------
-# Copyright (c) 2011-2016 Raytheon BBN Technologies
+# ----------------------------------------------------------------------
+# Copyright (c) 2013-2016 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -20,9 +20,11 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
-import os, os.path, sys
+import os
+import os.path
+import sys
 import json
 import optparse
 from gcf.omnilib.util.dossl import _do_ssl
@@ -31,6 +33,7 @@ import logging
 from gcf.omnilib.frameworks.framework_base import Framework_Base
 from portal_client import *
 from geni_constants import *
+
 
 # Generic client to speak XMLRPC/SSL SA/CH/MA API calls to
 
@@ -42,6 +45,7 @@ class MAClientFramework(Framework_Base):
         self.fwtype = "MA Ciient"
         self.opts = opts
 
+
 def parseOptions(args):
     parser = optparse.OptionParser()
 
@@ -49,43 +53,45 @@ def parseOptions(args):
     gcf_home = os.path.join(home, '.gcf')
 
     parser.add_option("--url", help="Server URL", default=None)
-    parser.add_option("--type", help="Object Type for generic v2 calls", default=None)
+    parser.add_option("--type", help="Object Type for generic v2 calls",
+                      default=None)
     parser.add_option("--urn", help="URN for API arguments", default=None)
-    parser.add_option("--key", help="Location of user key", \
-                          default=os.path.join(gcf_home, 'alice-key.pem'))
-    parser.add_option("--cert", help="Location of user cert", \
-                          default=os.path.join(gcf_home, 'alice-cert.pem'))
+    parser.add_option("--key", help="Location of user key",
+                      default=os.path.join(gcf_home, 'alice-key.pem'))
+    parser.add_option("--cert", help="Location of user cert",
+                      default=os.path.join(gcf_home, 'alice-cert.pem'))
     parser.add_option("--method", help="Name of method to invoke",
                       default="get_version")
-    parser.add_option("--page", help="Name of portal page to simulate (home, projects, slices)")
+    parser.add_option("--page",
+                      help="Name of portal page to simulate (home, projects, slices)")
     parser.add_option("--eppn", help="EPPN of user")
-    parser.add_option("--agg_url",  help="URL of aggregate in some API calls",
-                      default = None)
+    parser.add_option("--agg_url", help="URL of aggregate in some API calls",
+                      default=None)
     parser.add_option("--string_arg", help="String argument for some calls",
-                      default = None)
+                      default=None)
     parser.add_option("--string2_arg", help="second string argument for some calls",
-                      default = None)
+                      default=None)
     parser.add_option("--int_arg", help="Integer argument for some calls",
-                      type='int', default = None)
+                      type='int', default=None)
     parser.add_option("--int2_arg", help="second integer argument for some calls",
-                      type='int', default = None)
+                      type='int', default=None)
     parser.add_option("--int3_arg", help="third integer argument for some calls",
-                      type='int', default = None)
+                      type='int', default=None)
     parser.add_option("--uuid_arg", help="UUID argument for some calls",
-                      default = None)
+                      default=None)
     parser.add_option("--uuid2_arg", help="second UUID argument for some calls",
-                      default = None)
+                      default=None)
     parser.add_option("--uuid3_arg", help="third UUID argument for some calls",
-                      default = None)
+                      default=None)
     parser.add_option("--file_arg", help="FILE argument for some calls",
-                      default = None)
+                      default=None)
     parser.add_option("--options", help="JSON of options argument", default="{}")
     parser.add_option("--options_file", help="File containing JSON of options argument", default=None)
     parser.add_option("--attributes", help="JSON of attributes argument", default="{}")
     parser.add_option("--attributes_file", help="File containing JSON of attributes argument", default=None)
-    parser.add_option("--credentials", \
-                          help="List of comma-separated credential files", \
-                          default="")
+    parser.add_option("--credentials",
+                      help="List of comma-separated credential files",
+                      default="")
 
     [opts, args] = parser.parse_args(args)
     if len(opts.credentials) > 0:
@@ -97,17 +103,18 @@ def parseOptions(args):
             cred_file = cred_parts[0]
             cred_type = cred_parts[1]
             cred_data = open(cred_file).read()
-            cred_struct= {'geni_type' : cred_type, 'geni_version' : 1,
-                          'geni_value' : cred_data}
+            cred_struct = {'geni_type': cred_type, 'geni_version': 1,
+                           'geni_value': cred_data}
             cred_structs.append(cred_struct)
         opts.credentials = cred_structs
     else:
         opts.credentials = []
 
-    if opts.url == None:
+    if opts.url is None:
         raise Exception("URL is required argument")
 
     return opts, args
+
 
 def add_attribute(attributes, int_arg, uuid_arg):
     if int_arg == PROJECT_CONTEXT and uuid_arg:
@@ -115,7 +122,8 @@ def add_attribute(attributes, int_arg, uuid_arg):
     elif int_arg == SLICE_CONTEXT and uuid_arg:
         attributes['SLICE'] = uuid_arg
 
-def main(args = sys.argv, do_print=True):
+
+def main(args=sys.argv, do_print=True):
     logging.basicConfig()
     opts, args = parseOptions(args)
     client_options = json.loads(opts.options)
@@ -129,7 +137,7 @@ def main(args = sys.argv, do_print=True):
         print "OPTIONS = " + str(client_options)
     suppress_errors = None
     reason = "Testing"
-    config = {'cert' : opts.cert, 'key' : opts.key}
+    config = {'cert': opts.cert, 'key': opts.key}
 
     framework = MAClientFramework(config, {})
     client = framework.make_client(opts.url, opts.key, opts.cert,
@@ -147,18 +155,22 @@ def main(args = sys.argv, do_print=True):
     elif opts.method in ['get_version', 'get_trust_roots']:
         (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn)
     # Methods that take options argument
-    elif opts.method in ['lookup_member_authorities', 'lookup_slice_authorities', \
-                             'lookup_aggregates', \
-                             'lookup_authorities_for_urns' ]:
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    client_options)
+    elif opts.method in ['lookup_member_authorities',
+                         'lookup_slice_authorities',
+                         'lookup_aggregates',
+                         'lookup_authorities_for_urns']:
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                client_options)
     # Methods that take a URN and an aggregate URL argument
     elif opts.method in ['register_aggregate', 'remove_aggregate'] and opts.agg_url:
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    opts.urn, opts.agg_url, opts.credentials, client_options)
-    elif opts.int_arg is not None and opts.method in ['get_services_of_type', 'get_first_service_of_type', 'get_service_by_id']:
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    int(opts.int_arg))
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                opts.urn, opts.agg_url, opts.credentials,
+                                client_options)
+    elif (opts.int_arg is not None and
+          opts.method in ['get_services_of_type', 'get_first_service_of_type',
+                          'get_service_by_id']):
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                int(opts.int_arg))
     elif opts.method in ['get_services']:
         (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn)
     # Logging methods (test)
@@ -167,58 +179,59 @@ def main(args = sys.argv, do_print=True):
         attributes = {}
         add_attribute(attributes, opts.int_arg, opts.uuid_arg)
         add_attribute(attributes, opts.int2_arg, opts.uuid2_arg)
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    message, attributes, opts.credentials,
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                message, attributes, opts.credentials,
                                 client_options)
-    elif opts.method in [ 'get_log_entries_by_author']:
-        num_hours = 15*24
+    elif opts.method in ['get_log_entries_by_author']:
+        num_hours = 15 * 24
         user_id = '8e405a75-3ff7-4288-bfa5-111552fa53ce'
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    user_id, num_hours, opts.credentials,
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                user_id, num_hours, opts.credentials,
                                 client_options)
     elif opts.method in ['get_log_entries_for_context']:
         context_type = 'SLICE'
         context_id = '848e4a11-55eb-45df-a0e8-b79109fb0a88'
-        num_hours = 15*24
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    context_type, context_id, num_hours,
+        num_hours = 15 * 24
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                context_type, context_id, num_hours,
                                 opts.credentials, client_options)
     elif opts.method in ['get_log_entries_by_attributes']:
         type1 = 'SLICE'
         id1 = '848e4a11-55eb-45df-a0e8-b79109fb0a88'
         type2 = 'PROJECT'
         id2 = '8c042cf0-8389-48e0-aca1-782fd7a20794'
-        num_hours = 15*24
-        attribute_sets = [{type1 : id1}, {type2 : id2}]
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    attribute_sets, num_hours, opts.credentials,
+        num_hours = 15 * 24
+        attribute_sets = [{type1: id1}, {type2: id2}]
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                attribute_sets, num_hours, opts.credentials,
                                 client_options)
 
     elif opts.method in ['get_attributes_for_log_entry']:
-        event_id = '20360';
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    event_id, opts.credentials,
+        event_id = '20360'
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                event_id, opts.credentials,
                                 client_options)
     # Credential store methods
     elif opts.method in ['get_permissions']:
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    opts.uuid_arg, \
-                                    opts.credentials, client_options)
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                opts.uuid_arg,
+                                opts.credentials, client_options)
     elif opts.method in ['get_attributes']:
         context = 'None'
-        if opts.uuid2_arg: context = opts.uuid2_arg
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    opts.uuid_arg, \
-                                    opts.int_arg, context, \
-                                    opts.credentials, client_options)
+        if opts.uuid2_arg:
+            context = opts.uuid2_arg
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                opts.uuid_arg,
+                                opts.int_arg, context,
+                                opts.credentials, client_options)
     elif opts.method in ['lookup_keys']:
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    opts.credentials, client_options)
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                opts.credentials, client_options)
     elif opts.method in ['delete_key', 'update_key'] \
             and opts.string_arg and opts.urn:
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    opts.string_arg, \
-                                    opts.credentials, client_options)
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                opts.string_arg,
+                                opts.credentials, client_options)
 
     # Client Authorization methods
     elif opts.method in ['list_clients']:
@@ -240,18 +253,18 @@ def main(args = sys.argv, do_print=True):
             _do_ssl(framework, suppress_errors, reason, fcn,
                     opts.credentials, client_options)
 
-
     # Project request methods
     elif opts.method in ['create_request']:
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg,
-                    opts.uuid_arg, opts.int2_arg, opts.string_arg, opts.string2_arg, \
-                        opts.credentials, client_options)
+                    opts.uuid_arg, opts.int2_arg, opts.string_arg,
+                    opts.string2_arg,
+                    opts.credentials, client_options)
     elif opts.method in ['resolve_pending_request']:
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg,
-                    opts.int2_arg, opts.int3_arg, opts.string_arg, \
-                        opts.credentials, client_options)
+                    opts.int2_arg, opts.int3_arg, opts.string_arg,
+                    opts.credentials, client_options)
     elif opts.method in ['invite_member']:
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.int_arg,
@@ -261,8 +274,8 @@ def main(args = sys.argv, do_print=True):
     elif opts.method in ['accept_invitation']:
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn,
-                    opts.uuid_arg, # invite_id
-                    opts.uuid2_arg, # member_id
+                    opts.uuid_arg,  # invite_id
+                    opts.uuid2_arg,  # member_id
                     opts.credentials, client_options)
 
     elif opts.method in ['get_requests_for_context']:
@@ -288,7 +301,7 @@ def main(args = sys.argv, do_print=True):
         options = {}
         if opts.file_arg:
             csr = open(opts.file_arg).read()
-            options = {'csr' : csr}
+            options = {'csr': csr}
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.urn,
                     opts.credentials, options)
@@ -297,9 +310,10 @@ def main(args = sys.argv, do_print=True):
     elif opts.method in ['create_member'] and opts.string_arg:
 
         # Use the entered string_arg as the email to register a member
-        attributes =  [{"value" : opts.string_arg,"name" : "email_address","self_asserted":False}]
+        attributes = [{"value": opts.string_arg,
+                       "name": "email_address",
+                       "self_asserted": False}]
         options = {}
-
 
         # Send query message and retrieve the result and response message
         (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
@@ -333,29 +347,28 @@ def main(args = sys.argv, do_print=True):
     elif opts.method in ['add_member_privilege', 'revoke_member_privilege']:
         options = {}
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, opts.uuid_arg, \
-                        opts.string_arg, \
-                        opts.credentials, options)
+            _do_ssl(framework, suppress_errors, reason, fcn, opts.uuid_arg,
+                    opts.string_arg,
+                    opts.credentials, options)
 
     # Methods that take urn, credentials, options
     elif opts.method in ['get_credentials']:
         options = {}
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, opts.urn, \
-                        opts.credentials, options)
-
+            _do_ssl(framework, suppress_errors, reason, fcn, opts.urn,
+                    opts.credentials, options)
 
     # Generic Federation v2 API methods
     elif opts.method in ['lookup', 'create']:
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, opts.type, \
-                       opts.credentials, client_options)
+            _do_ssl(framework, suppress_errors, reason, fcn, opts.type,
+                    opts.credentials, client_options)
 
-    elif opts.method in ['update', 'delete', \
-                             'modify_membership', 'lookup_members', 'lookup_for_member']:
+    elif opts.method in ['update', 'delete', 'modify_membership',
+                         'lookup_members', 'lookup_for_member']:
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, opts.type, \
-                        opts.urn, opts.credentials, client_options)
+            _do_ssl(framework, suppress_errors, reason, fcn, opts.type,
+                    opts.urn, opts.credentials, client_options)
 
     # Portal query
     elif opts.method in ['portal_query']:
@@ -364,29 +377,24 @@ def main(args = sys.argv, do_print=True):
         project_id = opts.uuid_arg
         slice_id = opts.uuid2_arg
         (result, msg) = \
-            _do_ssl(framework, suppress_errors, reason, fcn, \
-                        member_eppn, project_id, slice_id)
-
-#    def add_member_privilege(self, cert, member_uid, privilege, credentials, options):
-
+            _do_ssl(framework, suppress_errors, reason, fcn,
+                    member_eppn, project_id, slice_id)
 
     # Methods that take attributes and options
     elif client_attributes:
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    client_attributes, \
-                                    opts.credentials, client_options)
-
-
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                client_attributes,
+                                opts.credentials, client_options)
 
     # Methods that take credentials and options and urn arguments
     elif opts.urn:
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    opts.urn, \
-                                    opts.credentials, client_options)
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                opts.urn,
+                                opts.credentials, client_options)
     # Methods that take credentials and options (and no urn) arguments
     else:
-        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn, \
-                                    opts.credentials, client_options)
+        (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,
+                                opts.credentials, client_options)
 
     if do_print:
         print "RESULT = " + str(result)


### PR DESCRIPTION
... and, pulling on the bit of yarn, fix 201 pep8 errors while I was there. These were largely pointless backslashes and too much or too little visual indent. Most importantly, there was mixed indentation (tabs and spaces) that really needed fixing.