### PR TITLE
Communicate max slice expiration in SA get_version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Communicate max slice expiration in SA get_version
+([#464](https://github.com/GENI-NSF/geni-ch/issues/464))
 
 ## Installation Notes
 

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -129,14 +129,17 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
         versionNumber = plugins.chapiv1rpc.chapi.Parameters.VERSION_NUMBER
         api_versions = {versionNumber: serverURL}
         implementation_info = get_implementation_info(SA_LOG_PREFIX)
-        version_info = {"VERSION": versionNumber,
-                        "URN ": self.urn,
-                        "IMPLEMENTATION": implementation_info,
-                        "SERVICES": SA.services,
-                        "CREDENTIAL_TYPES": SA.credential_types,
-                        "ROLES": attribute_type_names.values(),
-                        "API_VERSIONS": api_versions,
-                        "FIELDS": SA.supplemental_fields}
+        version_info = {
+            "VERSION": versionNumber,
+            "URN ": self.urn,
+            "IMPLEMENTATION": implementation_info,
+            "SERVICES": SA.services,
+            "CREDENTIAL_TYPES": SA.credential_types,
+            "ROLES": attribute_type_names.values(),
+            "API_VERSIONS": api_versions,
+            "FIELDS": SA.supplemental_fields,
+            "_GENI_MAX_SLICE_EXPIRATION_DAYS": SA.SLICE_MAX_RENEWAL_DAYS
+        }
         result = self._successReturn(version_info)
         return result
 

--- a/test/travis-build
+++ b/test/travis-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Limits as of May 13, 2016
-ERROR_LIMIT=3185
+# Limits as of June 8, 2016
+ERROR_LIMIT=3141
 WARNING_LIMIT=411
 
 RESULT=0


### PR DESCRIPTION
Client programs have no way to no what the max slice expiration is. Add
the max expiration to the slice authority get_version response so that
clients can use the information to determine requested slice lifetimes.

Use the key '_GENI_MAX_SLICE_EXPIRATION_DAYS' and set the value
appropriately with the unit of days from the constant used in the SA.

Fixes #464