### PR TITLE
Allow authorities to call lookup_project_members

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
   ([#525](https://github.com/GENI-NSF/geni-ch/issues/525))
 * Remove obsolete scripts related to GMOC monitoring
   ([#527](https://github.com/GENI-NSF/geni-ch/issues/527))
+* Remove obsolete scripts related to GMOC monitoring
+  ([#529](https://github.com/GENI-NSF/geni-ch/issues/529))
 
 ## Installation Notes
 

--- a/etc/slice_authority_policy.json
+++ b/etc/slice_authority_policy.json
@@ -149,6 +149,7 @@
    ],
    "policies" : [
      "ME.MAY_$METHOD<-ME.IS_OPERATOR",
+     "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
      "ME.MAY_$METHOD_$PROJECT<-ME.BELONGS_TO_$PROJECT"
     ]
   },


### PR DESCRIPTION
Add authority permission to lookup_project_members so that the portal's `geni-sync-wireless` script can use the clearinghouse APIs instead of direct database access.

Fixes #529 