### PR TITLE
Make geni-create-ma-crl work on CentOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Add xmlsec1 dependencies to RPM spec
   ([#525](https://github.com/GENI-NSF/geni-ch/issues/525))
+* Make geni-create-ma-crl work on CentOS
+  ([#526](https://github.com/GENI-NSF/geni-ch/issues/526))
 * Remove obsolete scripts related to GMOC monitoring
   ([#527](https://github.com/GENI-NSF/geni-ch/issues/527))
 * Remove obsolete scripts related to GMOC monitoring

--- a/bin/geni-create-ma-crl
+++ b/bin/geni-create-ma-crl
@@ -23,6 +23,9 @@
 # IN THE WORK.
 #----------------------------------------------------------------------
 
+# TODO: use autoconf/automake replacement of paths. Too many
+#       hardcoded paths below, not good.
+
 # Create an MA CRL file in /usr/share/geni-ch/chapi/ma
 
 CRLNUM=/usr/share/geni-ch/CA/crlnumber
@@ -30,7 +33,6 @@ TMP_CRLNUM=/tmp/crlnumber
 
 if [ ! -e "${CRLNUM}" ]; then
   echo "1000" > "${TMP_CRLNUM}"
-  chown www-data.www-data "${TMP_CRLNUM}"
   mv "${TMP_CRLNUM}" "${CRLNUM}"
 fi
 openssl ca -keyfile /usr/share/geni-ch/ma/ma-key.pem \


### PR DESCRIPTION
Remove the chmod line with an Ubuntu/Debian apache username. The
username doesn't work on CentOS, but more importantly the command
itself is a no-op because of the 'mv' in the very next line.

Fixes #526 