### PR TITLE
Add service enabling to CentOS install guide

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Add service enabling to CentOS install guide
+  ([#534](https://github.com/GENI-NSF/geni-ch/issues/534))
 
 ## Installation Notes
 

--- a/INSTALL-centos.md
+++ b/INSTALL-centos.md
@@ -301,3 +301,20 @@ geni-add-trusted-tool -d portal -u portal -p portal --host localhost \
 Open up Firewall if necessary
 -----------------------------
 If your machine is running firewall software it may be necessary for you to add rules to allow connections to the Clearinghouse.  The ports that need to be open are 22(SSH), 80(HTTP), 443(HTTPS) and 8444(Clearinghouse).
+
+Enable HTTPD and SHIBD services to start at boot time
+-----------------------------------------------------
+
+The following command will enable the HTTPD service (Apache) to start
+at boot time:
+
+````sh
+sudo systemctl enable httpd.service
+````
+
+The following command will verify that the HTTPD service is set to start
+at boot time. This should report "enabled".
+
+````sh
+sudo systemctl is-enabled httpd.service
+````


### PR DESCRIPTION
Add a section describing how to enable the httpd service to start
at boot time and how to verify that the httpd service is enabled.