### PR TITLE
Move one-time initialization to WSGI files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 
 * Add service enabling to CentOS install guide
   ([#534](https://github.com/GENI-NSF/geni-ch/issues/534))
+* Move one-time initialization to WSGI files
+  ([#542](https://github.com/GENI-NSF/geni-ch/issues/542))
+
 
 ## Installation Notes
 

--- a/test/travis-build
+++ b/test/travis-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Limits as of September 20, 2016
-ERROR_LIMIT=3083
+# Limits as of January 25, 2017
+ERROR_LIMIT=3081
 WARNING_LIMIT=391
 
 RESULT=0

--- a/tools/ch_server.py
+++ b/tools/ch_server.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------
-# Copyright (c) 2011-2016 Raytheon BBN Technologies
+# Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -37,34 +37,24 @@ import plugins.sarm.plugin
 
 from tools.chapi_log import *
 
-pm.registerService('xmlrpc', pm.XMLRPCHandler())
-pm.registerService('config', pm.ConfigDB())
-pm.registerService('rpcserver', pm.RESTServer())
-pm.registerService(pm.ENVIRONMENT_SERVICE, pm.WSGIEnvironment())
-
-initialized = False
-
 
 def initialize():
-    global initialized
-    if not initialized:
-        plugins.chapiv1rpc.plugin.setup()
-        plugins.chrm.plugin.setup()
-        plugins.csrm.plugin.setup()
-        plugins.flaskrest.plugin.setup()
-        plugins.logging.plugin.setup()
-        plugins.opsmon.plugin.setup()
-        plugins.marm.plugin.setup()
-        plugins.sarm.plugin.setup()
-        chapi_info("CH_SERVER",  "INITIALIZED CH_SERVER")
-        initialized = True
+    pm.registerService('xmlrpc', pm.XMLRPCHandler())
+    pm.registerService('config', pm.ConfigDB())
+    pm.registerService('rpcserver', pm.RESTServer())
+    pm.registerService(pm.ENVIRONMENT_SERVICE, pm.WSGIEnvironment())
+    plugins.chapiv1rpc.plugin.setup()
+    plugins.chrm.plugin.setup()
+    plugins.csrm.plugin.setup()
+    plugins.flaskrest.plugin.setup()
+    plugins.logging.plugin.setup()
+    plugins.opsmon.plugin.setup()
+    plugins.marm.plugin.setup()
+    plugins.sarm.plugin.setup()
+    chapi_info("CH_SERVER", "INITIALIZED CH_SERVER")
 
 
 def application(environ, start_response):
-
-    initialize()
-
-#    print "ENV = " + str(environ)
     start_response('200 OK', [('Content-Type', 'text/html')])
     try:
         result = handleCall(environ)
@@ -114,7 +104,8 @@ def handle_XMLRPC_call(environ):
         # Always clear the environment after the call is complete,
         # even if there was an exception
         envService.clearEnvironment()
-    response = xmlrpclib.dumps((method_response,), methodresponse=True, allow_none=True)
+    response = xmlrpclib.dumps((method_response,),
+                               methodresponse=True, allow_none=True)
     return response
 
 

--- a/tools/ch_server.wsgi
+++ b/tools/ch_server.wsgi
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------
-# Copyright (c) 2016 Raytheon BBN Technologies
+# Copyright (c) 2016-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -21,7 +21,10 @@
 # IN THE WORK.
 # ----------------------------------------------------------------------
 
-import sys
-import os
+import tools.ch_server
 
-from tools.ch_server import application as application
+# Perform one-time initialization
+tools.ch_server.initialize()
+
+# This is the WSGI entry point
+application = tools.ch_server.application


### PR DESCRIPTION
Remove the boolean global gate on initialization because it does not
work well in a multithreaded environment. Use the WSGI file for one-
time initializations. This should ensure that one-time initializations
happen once.

Fixes #542 