### PR TITLE
Require valid client certificates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,8 @@
   ([#534](https://github.com/GENI-NSF/geni-ch/issues/534))
 * Move one-time initialization to WSGI files
   ([#542](https://github.com/GENI-NSF/geni-ch/issues/542))
-
+* Require client certificate httpd config template
+  ([#544](https://github.com/GENI-NSF/geni-ch/issues/544))
 
 ## Installation Notes
 

--- a/templates/ch-ssl.conf.tmpl
+++ b/templates/ch-ssl.conf.tmpl
@@ -40,6 +40,13 @@ h/chapi/chapi
     WSGIScriptAlias /LOG @pkgdatadir@/chapi/chapi/tools/ch_server.wsgi
     WSGIScriptAliasMatch /info/*/* @pkgdatadir@/chapi/chapi/tools/ch_server.wsgi
 
+    # Use rewrite engine to show a relatively friendly page to
+    # clients who don't display SSL certs, regardless of what URL
+    # they requested on this vhost
+    RewriteEngine On
+    RewriteCond %{SSL:SSL_CLIENT_VERIFY} !^SUCCESS$
+    RewriteRule .* /index.html [L]
+
 </VirtualHost>
 
 Listen 8444


### PR DESCRIPTION
For httpd endpoints that are not otherwise protected, add a rewrite
rule that redirects users to the index page if they do not present
a valid client certificate. This restricts the monitoring info pages
to clients with a valid client certificate.

Fixes #544 