### PR TITLE
Define WSGIProcessGroup in ch-ssl.conf template

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
   ([#544](https://github.com/GENI-NSF/geni-ch/issues/544))
 * Convert timestamps for opsmon properly to GMT
   ([#546](https://github.com/GENI-NSF/geni-ch/issues/546))
+* Define "WSGIProcessGroup" in ch-ssl.conf template
+  ([#548](https://github.com/GENI-NSF/geni-ch/issues/548))
 
 ## Installation Notes
 

--- a/templates/ch-ssl.conf.tmpl
+++ b/templates/ch-ssl.conf.tmpl
@@ -14,8 +14,8 @@
 # Leave both in place so it works on both platforms.
 # ----------------------------------------------------------------------
 WSGIPythonPath /usr/share/geni-ch/chapi/chapi
-WSGIDaemonProcess ch_server display-name=%{GROUP} python-path=/usr/share/geni-c\
-h/chapi/chapi
+WSGIDaemonProcess ch_server display-name=%{GROUP} python-path=/usr/share/geni-ch/chapi/chapi
+WSGIProcessGroup ch_server
 
 <VirtualHost *:443>
     ServerName @ch_host@


### PR DESCRIPTION
On CentOS 7 with WSGI 3.4 and Apache 2.4, WSGIProcessGroup must be
defined in order to spawn WSGI in daemon mode. It is not enough to
have WSGIDaemonProcess defined; both must be defined.

Fixes #548 