### PR TITLE
Add a version file to support get_version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Add service enabling to CentOS install guide
   ([#534](https://github.com/GENI-NSF/geni-ch/issues/534))
+* Create a version file for get_version responses
+  ([#540](https://github.com/GENI-NSF/geni-ch/issues/540))
 * Move one-time initialization to WSGI files
   ([#542](https://github.com/GENI-NSF/geni-ch/issues/542))
 * Require client certificate httpd config template

--- a/Makefile.sync
+++ b/Makefile.sync
@@ -11,8 +11,6 @@ RSYNC_EXCLUDE = --exclude .git --exclude '*~' \
 RSYNC_DELETE = --delete --delete-excluded
 RSYNC_ARGS = -aztv $(RSYNC_EXCLUDE)
 
-GITHASH = etc/geni-chapi-githash
-
 # This will probably be "../geni-ch"
 SRC_DIR = ../$(notdir $(CURDIR))
 
@@ -21,23 +19,20 @@ SRC_DIR = ../$(notdir $(CURDIR))
 default:
 	echo "Choose a specific sync target."
 
-$(GITHASH): .git
-	git rev-parse HEAD > $@
-
-syncb: $(GITHASH)
+syncb:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) bigslide.gpolab.bbn.com:
 
-syncd: $(GITHASH)
+syncd:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) dagoola.gpolab.bbn.com:
 
-syncm: $(GITHASH)
+syncm:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) marilac.gpolab.bbn.com:
 
-synci: $(GITHASH)
+synci:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) illyrica.gpolab.bbn.com:
 
-syncc: $(GITHASH)
+syncc:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) cascade.gpolab.bbn.com:
 
-syncn: $(GITHASH)
+syncn:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) nye.gpolab.bbn.com:

--- a/configure.ac
+++ b/configure.ac
@@ -20,8 +20,6 @@ AC_ARG_ENABLE([gpo_lab],
 esac],[gpo_lab=false])
 AM_CONDITIONAL([GPO_LAB], [test x$gpo_lab = xtrue])
 
-AM_CONDITIONAL(INSTALL_GITHASH, [test -f etc/geni-chapi-githash])
-
 AC_CONFIG_FILES([Makefile plugins/Makefile tools/Makefile etc/Makefile])
 AC_CONFIG_FILES([bin/Makefile man/Makefile data/Makefile db/Makefile])
 AC_CONFIG_FILES([templates/Makefile])

--- a/etc/.gitignore
+++ b/etc/.gitignore
@@ -1,1 +1,0 @@
-geni-chapi-githash

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,13 +1,35 @@
 pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
 
+edit = sed -e 's|@VERSION[@]|$(VERSION)|g'
+
+TEMPLATES = geni-ch-version.txt
+
+TEMPLATES.IN = $(TEMPLATES:%=%.in)
+
+$(TEMPLATES): Makefile
+	rm -f $@ $@.tmp
+	srcdir=''; \
+		test -f ./$@.in || srcdir=$(srcdir)/; \
+		$(edit) $${srcdir}$@.in >$@.tmp
+	chmod a-w $@.tmp
+	mv $@.tmp $@
+
+%: $(srcdir)/%.in
+
+# Distribute but do not install
+EXTRA_DIST = $(TEMPLATES.IN)
+
+CLEANFILES = $(TEMPLATES)
+
 dist_pkgsysconf_DATA = \
 	example-chapi.ini \
 	example-parameters.json \
+	geni-ch-version.txt \
 	logging_config.conf \
 	credential_store_policy.json \
 	logging_policy.json \
 	member_authority_policy.json \
-	slice_authority_policy.json 
+	slice_authority_policy.json
 
 if INSTALL_GITHASH
 pkgsysconf_DATA = geni-chapi-githash

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -30,7 +30,3 @@ dist_pkgsysconf_DATA = \
 	logging_policy.json \
 	member_authority_policy.json \
 	slice_authority_policy.json
-
-if INSTALL_GITHASH
-pkgsysconf_DATA = geni-chapi-githash
-endif

--- a/etc/geni-ch-version.txt.in
+++ b/etc/geni-ch-version.txt.in
@@ -1,0 +1,1 @@
+@VERSION@

--- a/geni-chapi.spec
+++ b/geni-chapi.spec
@@ -47,6 +47,7 @@ rm -rf $RPM_BUILD_ROOT
 %config %{_sysconfdir}/%{name}/credential_store_policy.json
 %config %{_sysconfdir}/%{name}/example-chapi.ini
 %config %{_sysconfdir}/%{name}/example-parameters.json
+%config %{_sysconfdir}/%{name}/geni-ch-version.txt
 %config %{_sysconfdir}/%{name}/logging_config.conf
 %config %{_sysconfdir}/%{name}/logging_policy.json
 %config %{_sysconfdir}/%{name}/member_authority_policy.json

--- a/test/travis-build
+++ b/test/travis-build
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-# Limits as of January 25, 2017
-ERROR_LIMIT=3020
+# Limits as of January 26, 2017
+ERROR_LIMIT=3019
 WARNING_LIMIT=379
 
 RESULT=0
-ERROR_COUNT=`python test/pep8.py --ignore W . | wc -l`
-WARNING_COUNT=`python test/pep8.py --ignore E . | wc -l`
+ERROR_COUNT=`python test/pep8.py --filename '*.py,*.py.in' --ignore W . | wc -l`
+WARNING_COUNT=`python test/pep8.py --filename '*.py,*.py.in' --ignore E . | wc -l`
 
 if test $ERROR_COUNT -gt $ERROR_LIMIT
 then

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -3,10 +3,28 @@
 #       /usr/share/geni-chapi or similar
 tooldir = $(pkgdatadir)/../geni-ch/chapi/chapi/tools
 
-# TODO: Weed out unnecessary files from install.
-#       Candidates include any file that doesn't end
-#       in '.py'
+pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
 
+edit = sed -e 's|@pkgsysconfdir[@]|$(pkgsysconfdir)|g'
+
+TEMPLATES = chapi_utils.py
+
+TEMPLATES.IN = $(TEMPLATES:%=%.in)
+
+$(TEMPLATES): Makefile
+	rm -f $@ $@.tmp
+	srcdir=''; \
+		test -f ./$@.in || srcdir=$(srcdir)/; \
+		$(edit) $${srcdir}$@.in >$@.tmp
+	chmod a-w $@.tmp
+	mv $@.tmp $@
+
+%: $(srcdir)/%.in
+
+# Distribute but do not install
+EXTRA_DIST = $(TEMPLATES.IN)
+
+CLEANFILES = $(TEMPLATES)
 
 dist_tool_DATA = \
 	ABACManager.py \

--- a/tools/chapi_utils.py.in
+++ b/tools/chapi_utils.py.in
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------
-# Copyright (c) 2011-2016 Raytheon BBN Technologies
+# Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -119,4 +119,4 @@ def get_implementation_info(log_prefix):
         "code_url": CHAPI_CODE_URL,
         "code_release_date": str(code_timestamp),
         "site_update_date": str(code_timestamp)
-        }
+    }

--- a/tools/chapi_utils.py.in
+++ b/tools/chapi_utils.py.in
@@ -107,7 +107,7 @@ def get_code_timestamp(log_prefix):
                     "Can't find code tag file %s" % CHAPI_CODE_TAG_FILE)
     return code_timestamp
 
-CHAPI_CODE_TAG_FILE = "/etc/geni-chapi/geni-chapi-githash"
+CHAPI_CODE_TAG_FILE = "@pkgsysconfdir@/geni-ch-version.txt"
 CHAPI_CODE_URL = "https://github.com/GENI-NSF/geni-ch"
 
 


### PR DESCRIPTION
Remove the outdated and obsolete githash file. That worked in development and with manual installs (sometimes), but does not work with RPMs. Replace with `geni-ch-version`, a generated file that holds the version number of the clearinghouse software as defined in `configure.ac`. Read version data and timestamps from this new file.

Fixes #540 