### PR TITLE
Clean up PEP8 warnings and errors

### DIFF
--- a/plugins/chapiv1rpc/chapi/Clearinghouse.py
+++ b/plugins/chapiv1rpc/chapi/Clearinghouse.py
@@ -47,12 +47,12 @@ class CHv1Handler(HandlerBase):
                 mc._result = \
                     self._delegate.get_version(options, mc._session)
         return mc._result
-    
+
     # This call is unprotected: no checking of credentials
     # Return list of member authorities with matching and filter criteria
     # specified in options
     def lookup_member_authorities(self, options):
-        with MethodContext(self, SR_LOG_PREFIX, 'lookup_member_authorities', 
+        with MethodContext(self, SR_LOG_PREFIX, 'lookup_member_authorities',
                            {}, [], options, read_only=True, cert_required=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -65,7 +65,7 @@ class CHv1Handler(HandlerBase):
     # Return list of slice authorities with matching and filter criteria
     # specified in options
     def lookup_slice_authorities(self, options):
-        with MethodContext(self, SR_LOG_PREFIX, 'lookup_slice_authorities', 
+        with MethodContext(self, SR_LOG_PREFIX, 'lookup_slice_authorities',
                            {}, [], options, read_only=True, cert_required=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -78,7 +78,7 @@ class CHv1Handler(HandlerBase):
     # Return list of aggregates with matching and filter criteria`
     # specified in options
     def lookup_aggregates(self, options):
-         with MethodContext(self, SR_LOG_PREFIX, 'lookup_aggregates', 
+         with MethodContext(self, SR_LOG_PREFIX, 'lookup_aggregates',
                            {}, [], options, read_only=True, cert_required=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -101,12 +101,12 @@ class CHv1Handler(HandlerBase):
     # This call is unprotected: no checking of credentials
     # Return URL of authority (slice or member) for given URN
     def lookup_authorities_for_urns(self, urns):
-         with MethodContext(self, SR_LOG_PREFIX, 
-                            'lookup_authorities_for_urns', 
+         with MethodContext(self, SR_LOG_PREFIX,
+                            'lookup_authorities_for_urns',
                            {'urns' : urns}, [], {}, read_only=True, cert_required=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_authorities__for_urns(mc._client_cert, 
+                    self._delegate.lookup_authorities__for_urns(mc._client_cert,
                                                                 urns,
                                                                 mc._session)
          return mc._result
@@ -115,12 +115,12 @@ class CHv1Handler(HandlerBase):
     # Return list of trust roots trusted by authorities and aggregates of
     # the federation associated with this Clearinghouse
     def get_trust_roots(self):
-         with MethodContext(self, SR_LOG_PREFIX, 
+         with MethodContext(self, SR_LOG_PREFIX,
                             'get_trust_roots',
                            {}, [], {}, read_only=True, cert_required=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.get_trust_roots(mc._client_cert, 
+                    self._delegate.get_trust_roots(mc._client_cert,
                                                    mc._session)
          return mc._result
 
@@ -128,10 +128,10 @@ class CHv1Handler(HandlerBase):
 # Must be  implemented in a derived class, and that derived class
 # must call setDelegate on the handler
 class CHv1DelegateBase(DelegateBase):
-    
+
     def __init__(self):
         super(CHv1DelegateBase, self).__init__(ch_logger)
-    
+
     def get_version(self, options, session):
         raise CHAPIv1NotImplementedError('')
 
@@ -152,5 +152,3 @@ class CHv1DelegateBase(DelegateBase):
 
     def lookup_services(self, client_cert, options, session):
         raise CHAPIv1NotImplementedError('')
-        
-

--- a/plugins/chapiv1rpc/chapi/DelegateBase.py
+++ b/plugins/chapiv1rpc/chapi/DelegateBase.py
@@ -21,7 +21,7 @@
 # IN THE WORK.
 #----------------------------------------------------------------------
 
-# Base class for delegate bases that want to authenticate, authorize, 
+# Base class for delegate bases that want to authenticate, authorize,
 # Return GENI-style returns
 
 import tools.pluginmanager as pm
@@ -50,7 +50,7 @@ class DelegateBase(object):
         config = pm.getService("config")
   #      cert_root = expand_amsoil_path(config.get("chapiv1rpc.ch_cert_root"))
         cert_root = config.get("chapiv1rpc.ch_cert_root")
-        
+
         if client_cert == None:
             # work around if the certificate could not be acquired due to the shortcommings of the werkzeug library
             if config.get("flask.debug"):
@@ -64,7 +64,7 @@ class DelegateBase(object):
             cred_verifier.verify_from_strings(client_cert, geni_credentials, slice_urn, privileges)
         except Exception as e:
             raise CHAPIv1ForbiddenError(str(e))
-        
+
         user_gid = gid.GID(string=client_cert)
         user_urn = user_gid.get_urn()
         user_uuid = user_gid.get_uuid()
@@ -81,7 +81,7 @@ class DelegateBase(object):
         self.logger.error(e)
         self.logger.error(traceback.format_exc())
         return {'code' :  e.code , 'value' : None, 'output' : str(e) }
-        
+
     def _successReturn(self, result):
         """Assembles a GENI compliant return result for successful methods."""
         return { 'code' :  0 , 'value' : result, 'output' : '' }

--- a/plugins/chapiv1rpc/chapi/Exceptions.py
+++ b/plugins/chapiv1rpc/chapi/Exceptions.py
@@ -111,4 +111,3 @@ class CHAPIv1ConfigurationError(CHAPIv1BaseError):
         super(self.__class__, self).__init__(CONFIGURATION_ERROR, \
                                                  'CONFIGURATION', \
                                                  'CONFIG_ERROR', comment)
-

--- a/plugins/chapiv1rpc/chapi/GuardBase.py
+++ b/plugins/chapiv1rpc/chapi/GuardBase.py
@@ -38,19 +38,19 @@ class GuardBase(object):
 
     # Adjust the client identity in case the credentials and options
     # indicate that the caller of the method is not the 'true' caller
-    # This method is intended to be overwritten by clients that 
+    # This method is intended to be overwritten by clients that
     # support 'speaks-for' semantics
     # Returns:
-    #   agent_cert - The certificate of the true caller 
+    #   agent_cert - The certificate of the true caller
     #          (which may or may not be the client_cert)
-    #   revised_options - Any changes to optiosn to reflect the change in 
-    #         identity (e.g. placing the original client_cert in as an 
+    #   revised_options - Any changes to optiosn to reflect the change in
+    #         identity (e.g. placing the original client_cert in as an
     #         option for later accountability)
     def adjust_client_identity(self, client_cert, credentials, options,
                                trusted_roots):
         # Default implementation returns the given client_cert and options
         return client_cert, options
-        
+
 
 
     # Check that the results to the given method are permitted

--- a/plugins/chapiv1rpc/chapi/MemberAuthority.py
+++ b/plugins/chapiv1rpc/chapi/MemberAuthority.py
@@ -57,7 +57,7 @@ class MAv1Handler(HandlerBase):
         else:
             result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
         return result
-            
+
     def update(self, type, urn, credentials, options):
         if type == "MEMBER":
             result = \
@@ -68,7 +68,7 @@ class MAv1Handler(HandlerBase):
         else:
             result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
         return result
-            
+
     def delete(self, type, urn, credentials, options):
         if type == "MEMBER":
             result = \
@@ -79,7 +79,7 @@ class MAv1Handler(HandlerBase):
         else:
              result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
         return result
-            
+
     def lookup(self, type, credentials, options):
         if not isinstance(options, dict):
             return self._errorReturn(CHAPIv1ArgumentError("Options argument must be dictionary"))
@@ -120,7 +120,7 @@ class MAv1Handler(HandlerBase):
                            {}, credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = self._delegate.lookup_allowed_member_info(mc._client_cert,
-                                                                       credentials, 
+                                                                       credentials,
                                                                        options,
                                                                        mc._session)
         return mc._result
@@ -128,15 +128,15 @@ class MAv1Handler(HandlerBase):
     def lookup_public_member_info(self, credentials, options):
         """Return public information about members specified in options
         filter and query fields
-        
+
         This call is unprotected: no checking of credentials
         """
-        with MethodContext(self, MA_LOG_PREFIX, 'lookup_public_member_info', 
+        with MethodContext(self, MA_LOG_PREFIX, 'lookup_public_member_info',
                            {}, credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_public_member_info(mc._client_cert, 
-                                                             credentials, 
+                    self._delegate.lookup_public_member_info(mc._client_cert,
+                                                             credentials,
                                                              options,
                                                              mc._session)
         return mc._result
@@ -148,12 +148,12 @@ class MAv1Handler(HandlerBase):
         This call is protected
         Authorized by client cert and credentials
         """
-        with MethodContext(self, MA_LOG_PREFIX, 'lookup_private_member_info', 
+        with MethodContext(self, MA_LOG_PREFIX, 'lookup_private_member_info',
                            {}, credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_private_member_info(mc._client_cert, 
-                                                              credentials, 
+                    self._delegate.lookup_private_member_info(mc._client_cert,
+                                                              credentials,
                                                               options,
                                                               mc._session)
         return mc._result
@@ -165,13 +165,13 @@ class MAv1Handler(HandlerBase):
         This call is protected
         Authorized by client cert and credentials
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'lookup_identifying_member_info', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'lookup_identifying_member_info',
                            {}, credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_identifying_member_info(mc._client_cert, 
-                                                                  credentials, 
+                    self._delegate.lookup_identifying_member_info(mc._client_cert,
+                                                                  credentials,
                                                                   options,
                                                                   mc._session)
         return mc._result
@@ -183,89 +183,89 @@ class MAv1Handler(HandlerBase):
         This call is protected
         Authorized by client cert and credentials
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'lookup_public_identifying_member_info', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'lookup_public_identifying_member_info',
                            {}, credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_public_identifying_member_info(mc._client_cert, 
-                                                                  credentials, 
+                    self._delegate.lookup_public_identifying_member_info(mc._client_cert,
+                                                                  credentials,
                                                                   options,
                                                                   mc._session)
         return mc._result
 
     def lookup_login_info(self, credentials, options):
-        """Return member public cert/key and private key for user by EPPN. 
+        """Return member public cert/key and private key for user by EPPN.
         For authorities only.
         This call is protected
         Authorized by client cert and credentials
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
+        with MethodContext(self, MA_LOG_PREFIX,
                            'lookup_login_info',
                            {}, credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_login_info(mc._client_cert, 
-                                                     credentials, 
+                    self._delegate.lookup_login_info(mc._client_cert,
+                                                     credentials,
                                                      options,
                                                      mc._session)
         return mc._result
 
     def get_credentials(self, member_urn, credentials, options):
         """Get credentials for given user
-        
+
         This call is protected
         Authorization based on client cert and given credentials
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'get_credentials', 
-                           {'member_urn' : member_urn}, 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'get_credentials',
+                           {'member_urn' : member_urn},
                            credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.get_credentials(mc._client_cert, 
-                                                   member_urn, 
-                                                   credentials, 
+                    self._delegate.get_credentials(mc._client_cert,
+                                                   member_urn,
+                                                   credentials,
                                                    options,
                                                    mc._session)
         return mc._result
 
     def update_member_info(self, member_urn, credentials, options):
         """Update given member with new data provided in options
-        
+
         This call is protected
         Authorized by client cert and credentials
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'update_member_info', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'update_member_info',
                            {'member_urn' : member_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.update_member_info(mc._client_cert, 
+                    self._delegate.update_member_info(mc._client_cert,
                                                       member_urn,
-                                                      credentials, 
+                                                      credentials,
                                                       options,
                                                       mc._session)
         return mc._result
 
     def create_member(self, attributes, credentials, options):
-        """Create a new member using the specified attributes.  Attribute email is 
+        """Create a new member using the specified attributes.  Attribute email is
         required.  Returns the attributes of the resulting member record, including
         the uid and urn.
-        
+
         This call is protected
         Authorized by client cert and credentials
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
+        with MethodContext(self, MA_LOG_PREFIX,
                            'create_member',
-                           {'attributes' : attributes}, 
+                           {'attributes' : attributes},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.create_member(mc._client_cert, 
+                    self._delegate.create_member(mc._client_cert,
                                                  attributes,
-                                                 credentials, 
+                                                 credentials,
                                                  options,
                                                  mc._session)
         return mc._result
@@ -278,18 +278,18 @@ class MAv1Handler(HandlerBase):
             member_urn: URN of member for which to retrieve credentials
             options: 'fields' containing the fields for the key pair being stored
         Return:
-            Dictionary of name/value pairs for created key record 
+            Dictionary of name/value pairs for created key record
             including the KEY_ID
-       Should return DUPLICATE_ERROR if a key with the same KEY_ID is 
+       Should return DUPLICATE_ERROR if a key with the same KEY_ID is
        already stored for given user
        """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'create_key', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'create_key',
                            {}, credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.create_key(mc._client_cert, 
-                                              credentials, 
+                    self._delegate.create_key(mc._client_cert,
+                                              credentials,
                                               options,
                                               mc._session)
         return mc._result
@@ -300,18 +300,18 @@ class MAv1Handler(HandlerBase):
             key_id: KEY_ID (unique for member/key fingerprint) of key(s) to be deleted
         Return:
             True if succeeded
-            
+
         Should return ARGUMENT_ERROR if no such key is found for user
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'delete_key', 
-                           {'key_id' : key_id}, 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'delete_key',
+                           {'key_id' : key_id},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.delete_key(mc._client_cert, 
+                    self._delegate.delete_key(mc._client_cert,
                                               key_id,
-                                              credentials, 
+                                              credentials,
                                               options,
                                               mc._session)
         return mc._result
@@ -319,65 +319,65 @@ class MAv1Handler(HandlerBase):
     def update_key(self, key_id, credentials, options):
         """
         Update the details of a key pair for given member
-        
+
         Arguments:
           member_urn: urn of member for which to delete key pair
           key_id: KEY_ID (fingerprint) of key pair to be deleted
-          options: 'fields' containing fields for key pairs that are permitted 
+          options: 'fields' containing fields for key pairs that are permitted
         for update
         Return:
             True if succeeded
         Should return ARGUMENT_ERROR if no such key is found for user
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'update_key', 
-                           {'key_id' : key_id}, 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'update_key',
+                           {'key_id' : key_id},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.update_key(mc._client_cert, 
+                    self._delegate.update_key(mc._client_cert,
                                               key_id,
-                                              credentials, 
+                                              credentials,
                                               options,
                                               mc._session)
         return mc._result
 
     def lookup_keys(self, credentials, options):
-        """Lookup keys for given match criteria return fields in given 
+        """Lookup keys for given match criteria return fields in given
         #  filter criteria
         #
         # Arguments:
-        # options: 'match' for query match criteria, 'filter' for fields 
+        # options: 'match' for query match criteria, 'filter' for fields
         #    to be returned
         # Return:
-        #  Dictionary (indexed by member_urn) of dictionaries containing 
+        #  Dictionary (indexed by member_urn) of dictionaries containing
         #     name/value pairs for all keys registered for that given user.
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'lookup_keys', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'lookup_keys',
                            {}, credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.lookup_keys(mc._client_cert, 
-                                              credentials, 
+                    self._delegate.lookup_keys(mc._client_cert,
+                                              credentials,
                                               options,
                                               mc._session)
         return mc._result
 
     def create_certificate(self, member_urn, credentials, options):
         """Methods for managing user certs
-        # options: 
+        # options:
         # 'csr' => certificate signing request (if null, create cert/key)
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'create_certificate', 
-                           {'member_urn' : member_urn}, 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'create_certificate',
+                           {'member_urn' : member_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.create_certificate(mc._client_cert, 
+                    self._delegate.create_certificate(mc._client_cert,
                                               member_urn,
-                                              credentials, 
+                                              credentials,
                                               options,
                                               mc._session)
         return mc._result
@@ -386,8 +386,8 @@ class MAv1Handler(HandlerBase):
     def list_clients(self):
         """
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'list_clients', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'list_clients',
                            {}, [], {}, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
@@ -397,9 +397,9 @@ class MAv1Handler(HandlerBase):
     def list_authorized_clients(self, member_id):
         """
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'list_authorized_clients', 
-                           {'member_id' : member_id}, [], {}, 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'list_authorized_clients',
+                           {'member_id' : member_id}, [], {},
                            read_only=True) as mc:
             if not mc._error:
                 mc._result = \
@@ -411,8 +411,8 @@ class MAv1Handler(HandlerBase):
     def authorize_client(self, member_id, client_urn, authorize_sense):
         """
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'authorize_client', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'authorize_client',
                            {'member_id' : member_id,'client_urn' : client_urn,
                             'authorize_sense' : authorize_sense},
                            [], {}, read_only=False) as mc:
@@ -428,11 +428,11 @@ class MAv1Handler(HandlerBase):
 
     # member disable API
     def enable_user(self, member_urn, enable_sense, credentials, options):
-        """Enable or disable a user based on URN. If enable_sense is False, then user 
+        """Enable or disable a user based on URN. If enable_sense is False, then user
         will be disabled.
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'enable_user', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'enable_user',
                            {'member_urn' : member_urn,
                             'enable_sense' : enable_sense},
                            credentials, options, read_only=False) as mc:
@@ -451,8 +451,8 @@ class MAv1Handler(HandlerBase):
         """Add a privilege to a member.
         privilege is either OPERATOR or PROJECT_LEAD
         """
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'add_member_privilege', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'add_member_privilege',
                            {'member_uid' : member_uid,'privilege' : privilege},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
@@ -467,8 +467,8 @@ class MAv1Handler(HandlerBase):
 
     def revoke_member_privilege(self, member_uid, privilege, credentials, options):
         """Revoke a privilege for a member."""
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'revoke_member_privilege', 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'revoke_member_privilege',
                            {'member_uid' : member_uid,'privilege' : privilege},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
@@ -485,17 +485,17 @@ class MAv1Handler(HandlerBase):
                              member_urn, name, value, self_asserted,
                              credentials, options):
         """Add an attribute to member"""
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'add_member_attribute', 
-                           {'member_urn' : member_urn, 
-                            'name' : name, 'value' : value, 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'add_member_attribute',
+                           {'member_urn' : member_urn,
+                            'name' : name, 'value' : value,
                             'self_asserted' : self_asserted},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
                     self._delegate.add_member_attribute(mc._client_cert,
                                                         member_urn,
-                                                        name, 
+                                                        name,
                                                         value,
                                                         self_asserted,
                                                         credentials,
@@ -503,20 +503,20 @@ class MAv1Handler(HandlerBase):
                                                         mc._session)
         return mc._result
 
-    def remove_member_attribute(self, 
+    def remove_member_attribute(self,
                                 member_urn, name,
                                 credentials, options, value=None):
         """Remove attribute to member"""
-        with MethodContext(self, MA_LOG_PREFIX, 
-                           'remove_member_attribute', 
-                           {'member_urn' : member_urn, 'name' : name, 
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'remove_member_attribute',
+                           {'member_urn' : member_urn, 'name' : name,
                             'value' : value},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
                     self._delegate.remove_member_attribute(mc._client_cert,
                                                         member_urn,
-                                                        name, 
+                                                        name,
                                                         credentials,
                                                         options,
                                                         mc._session, value)
@@ -530,7 +530,7 @@ class MAv1DelegateBase(DelegateBase):
 
     def __init__(self):
         super(MAv1DelegateBase, self).__init__(ma_logger)
-    
+
     # This call is unprotected: no checking of credentials
     def get_version(self, options):
         raise CHAPIv1NotImplementedError('')
@@ -547,17 +547,17 @@ class MAv1DelegateBase(DelegateBase):
         raise CHAPIv1NotImplementedError('')
 
     # This call is unprotected: no checking of credentials
-    def lookup_public_member_info(self, client_cert, 
+    def lookup_public_member_info(self, client_cert,
                                   credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
     # This call is protected
-    def lookup_private_member_info(self, client_cert, 
+    def lookup_private_member_info(self, client_cert,
                                    credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
     # This call is protected
-    def lookup_identifying_member_info(self, client_cert, 
+    def lookup_identifying_member_info(self, client_cert,
                                        credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
@@ -570,17 +570,17 @@ class MAv1DelegateBase(DelegateBase):
         raise CHAPIv1NotImplementedError('')
 
     # This call is protected
-    def get_credentials(self, client_cert, member_urn, 
+    def get_credentials(self, client_cert, member_urn,
                         credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
     # This call is protected
-    def update_member_info(self, client_cert, member_urn, 
+    def update_member_info(self, client_cert, member_urn,
                            credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
     # This call is protected
-    def create_member(self, client_cert, attributes, 
+    def create_member(self, client_cert, attributes,
                       credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
@@ -589,11 +589,11 @@ class MAv1DelegateBase(DelegateBase):
     def create_key(self, client_cert, credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
-    def delete_key(self, client_cert, key_id, 
+    def delete_key(self, client_cert, key_id,
                    credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
-    def update_key(self, client_cert, key_id, 
+    def update_key(self, client_cert, key_id,
                    credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
@@ -620,7 +620,7 @@ class MAv1DelegateBase(DelegateBase):
         raise CHAPIv1NotImplementedError('')
 
     # Private API
-    def enable_user(self, client_cert, member_urn, enable_sense, 
+    def enable_user(self, client_cert, member_urn, enable_sense,
                     credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
@@ -632,8 +632,8 @@ class MAv1DelegateBase(DelegateBase):
                                 credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 
-    def add_member_attribute(self, client_cert, member_urn, att_name, 
-                             att_value, att_self_asserted, 
+    def add_member_attribute(self, client_cert, member_urn, att_name,
+                             att_value, att_self_asserted,
                              credentials, options, session):
         raise CHAPIv1NotImplementedError('')
 

--- a/plugins/chapiv1rpc/chapi/MethodContext.py
+++ b/plugins/chapiv1rpc/chapi/MethodContext.py
@@ -33,7 +33,7 @@ import traceback
 
 # Class to wrap all calls from handlers to delegates
 # Holding method context
-# 
+#
 # Call should :
 #  set method
 #  grab request cert and pull out email
@@ -64,7 +64,7 @@ import traceback
 #  return mc._result
 
 class MethodContext:
-    def __init__(self, 
+    def __init__(self,
                  handler, # Handler object (e.g. SliceAuthority, MemberAuthority)
                  log_prefix, # Prefix (e.g. SA, LOG, MA) to use for logging messages
                  method_name, # Name of invoked method
@@ -74,7 +74,7 @@ class MethodContext:
                  read_only, # Whether the method is read-only (and thus no need to commit)
                  session=None, # Optionally provide an existing session in which to perform method
                  cert_required=True, # Whether the client_cert is required
-                 create_session=True):  # Whether the method requires a DB session 
+                 create_session=True):  # Whether the method requires a DB session
         self._handler = handler
         self._log_prefix = log_prefix
         self._method_name = method_name
@@ -123,7 +123,7 @@ class MethodContext:
         new_client_cert, new_options = \
             self._handler._guard.adjust_client_identity(self._client_cert,
                                                         self._credentials,
-                                                        self._options, 
+                                                        self._options,
                                                         trusted_roots)
 
         if (self._client_cert != new_client_cert):
@@ -177,7 +177,7 @@ class MethodContext:
             # If a guard is provided validate the call
             if self._handler._guard:
                 # Validate the call (arguments and authorization)
-                self._handler._guard.validate_call(self._client_cert, 
+                self._handler._guard.validate_call(self._client_cert,
                                                    self._method_name,
                                                    self._credentials,
                                                    self._options,
@@ -190,7 +190,7 @@ class MethodContext:
         finally:
             return self
 
-    # Handle any error in MethodContext processing 
+    # Handle any error in MethodContext processing
     # Set the error and result fields
     # log traceback for certain errors
     def _handleError(self, e, tb=None):
@@ -229,7 +229,7 @@ class MethodContext:
                     self._handler._log.error(pretty_db_error_traceback)
                 else:
                     self._handleError(db_error, exc_traceback)
-                
+
 
         # Log the result
         chapi_log_result(self._log_prefix, self._method_name,
@@ -237,10 +237,3 @@ class MethodContext:
 
         # Returning True means not to propagate the exception. We've handled it here.
         return True
-
-
-
-
-
-
-

--- a/plugins/chapiv1rpc/plugin.py
+++ b/plugins/chapiv1rpc/plugin.py
@@ -38,7 +38,7 @@ def setup():
     # register xmlrpc endpoint
     xmlrpc = pm.getService('xmlrpc')
 
-    # Invoke the CH, SA and MA and set them with default/dummy 
+    # Invoke the CH, SA and MA and set them with default/dummy
     # guards and delegates
     # Subsequent plugins should replace these with proper guard and delegate
     # implementations

--- a/plugins/chrm/CHDatabaseEngine.py
+++ b/plugins/chrm/CHDatabaseEngine.py
@@ -1,24 +1,24 @@
-#----------------------------------------------------------------------         
+#----------------------------------------------------------------------
 # Copyright (c) 2011-2016 Raytheon BBN Technologies
-#                                                                               
-# Permission is hereby granted, free of charge, to any person obtaining         
-# a copy of this software and/or hardware specification (the "Work") to         
-# deal in the Work without restriction, including without limitation the        
-# rights to use, copy, modify, merge, publish, distribute, sublicense,          
-# and/or sell copies of the Work, and to permit persons to whom the Work        
-# is furnished to do so, subject to the following conditions:                   
-#                                                                               
-# The above copyright notice and this permission notice shall be                
-# included in all copies or substantial portions of the Work.                   
-#                                                                               
-# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS           
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF                    
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND                         
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT                   
-# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,                  
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,            
-# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS            
-# IN THE WORK.                                                                  
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and/or hardware specification (the "Work") to
+# deal in the Work without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Work, and to permit persons to whom the Work
+# is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Work.
+#
+# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+# IN THE WORK.
 #----------------------------------------------------------------------
 
 import tools.pluginmanager as pm
@@ -99,5 +99,3 @@ class CHDatabaseEngine:
     # Get a new session on the database engine
     def getSession(self):
         return self.session_class()
-
-

--- a/plugins/chrm/CHv1Guard.py
+++ b/plugins/chrm/CHv1Guard.py
@@ -73,4 +73,3 @@ class CHv1Guard(ABACGuardBase):
 
     def get_row_check(self, method):
         return None
-

--- a/plugins/chrm/__init__.py
+++ b/plugins/chrm/__init__.py
@@ -20,4 +20,3 @@
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
 #----------------------------------------------------------------------
-

--- a/plugins/chrm/plugin.py
+++ b/plugins/chrm/plugin.py
@@ -51,5 +51,3 @@ def setup():
 
     xmlrpc = pm.getService('xmlrpc')
     xmlrpc.registerXMLRPC('sr1', sr_handler, '/SR')
-
-

--- a/plugins/csrm/__init__.py
+++ b/plugins/csrm/__init__.py
@@ -20,4 +20,3 @@
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
 #----------------------------------------------------------------------
-

--- a/plugins/csrm/plugin.py
+++ b/plugins/csrm/plugin.py
@@ -39,6 +39,3 @@ def setup():
 
     xmlrpc = pm.getService('xmlrpc')
     xmlrpc.registerXMLRPC('cs1', cs_handler, '/CS')
-
-
-

--- a/plugins/flaskrest/__init__.py
+++ b/plugins/flaskrest/__init__.py
@@ -20,4 +20,3 @@
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
 #----------------------------------------------------------------------
-

--- a/plugins/flaskrest/plugin.py
+++ b/plugins/flaskrest/plugin.py
@@ -48,6 +48,3 @@ def setup():
     flask_server = pm.getService('rpcserver')
     flask_rest = FlaskREST(flask_server)
     pm.registerService('rest', flask_rest)
-
-
-

--- a/plugins/logging/__init__.py
+++ b/plugins/logging/__init__.py
@@ -20,4 +20,3 @@
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
 #----------------------------------------------------------------------
-

--- a/plugins/logging/plugin.py
+++ b/plugins/logging/plugin.py
@@ -34,11 +34,8 @@ def setup():
     log_delegate = Loggingv1Delegate()
     log_handler.setDelegate(log_delegate)
 
-    log_guard = Loggingv1Guard() 
+    log_guard = Loggingv1Guard()
     log_handler.setGuard(log_guard)
 
     xmlrpc = pm.getService('xmlrpc')
     xmlrpc.registerXMLRPC('log1', log_handler, '/LOG')
-
-
-

--- a/plugins/marm/__init__.py
+++ b/plugins/marm/__init__.py
@@ -20,4 +20,3 @@
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
 #----------------------------------------------------------------------
-

--- a/plugins/marm/plugin.py
+++ b/plugins/marm/plugin.py
@@ -1,24 +1,24 @@
-#----------------------------------------------------------------------         
+#----------------------------------------------------------------------
 # Copyright (c) 2011-2016 Raytheon BBN Technologies
-#                                                                               
-# Permission is hereby granted, free of charge, to any person obtaining         
-# a copy of this software and/or hardware specification (the "Work") to         
-# deal in the Work without restriction, including without limitation the        
-# rights to use, copy, modify, merge, publish, distribute, sublicense,          
-# and/or sell copies of the Work, and to permit persons to whom the Work        
-# is furnished to do so, subject to the following conditions:                   
-#                                                                               
-# The above copyright notice and this permission notice shall be                
-# included in all copies or substantial portions of the Work.                   
-#                                                                               
-# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS           
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF                    
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND                         
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT                   
-# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,                  
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,            
-# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS            
-# IN THE WORK.                                                                  
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and/or hardware specification (the "Work") to
+# deal in the Work without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Work, and to permit persons to whom the Work
+# is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Work.
+#
+# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+# IN THE WORK.
 #----------------------------------------------------------------------
 
 import tools.pluginmanager as pm

--- a/plugins/opsmon/__init__.py
+++ b/plugins/opsmon/__init__.py
@@ -20,4 +20,3 @@
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
 #----------------------------------------------------------------------
-

--- a/plugins/opsmon/plugin.py
+++ b/plugins/opsmon/plugin.py
@@ -32,11 +32,7 @@ def setup():
     rest = pm.getService("rest")
     opsmon_handler = OpsMonHandler()
     pm.registerService('opsmon_handler', opsmon_handler)
-    rest.registerREST('opsmon',  OpsMonHandler.handle_opsmon_request, 
+    rest.registerREST('opsmon',  OpsMonHandler.handle_opsmon_request,
                       '/info/<variety>/<id>',
                       methods=["GET"],
                       defaults={})
-
-
-
-

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -34,11 +34,8 @@ def setup():
     log_delegate = Loggingv1Delegate()
     log_handler.setDelegate(log_delegate)
 
-    log_guard = Loggingv1Guard() 
+    log_guard = Loggingv1Guard()
     log_handler.setGuard(log_guard)
 
     xmlrpc = pm.getService('xmlrpc')
     xmlrpc.registerXMLRPC('log1', log_handler, '/LOG')
-
-
-

--- a/plugins/sarm/__init__.py
+++ b/plugins/sarm/__init__.py
@@ -20,4 +20,3 @@
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
 #----------------------------------------------------------------------
-

--- a/plugins/sarm/plugin.py
+++ b/plugins/sarm/plugin.py
@@ -37,4 +37,3 @@ def setup():
     handler = pm.getService('sav1handler')
     handler.setDelegate(delegate)
     handler.setGuard(guard)
-

--- a/test/travis-build
+++ b/test/travis-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Limits as of January 26, 2017
-ERROR_LIMIT=3019
+# Limits as of February 2, 2017
+ERROR_LIMIT=2898
 WARNING_LIMIT=379
 
 RESULT=0

--- a/test/travis-build
+++ b/test/travis-build
@@ -2,7 +2,7 @@
 
 # Limits as of February 2, 2017
 ERROR_LIMIT=2898
-WARNING_LIMIT=379
+WARNING_LIMIT=62
 
 RESULT=0
 ERROR_COUNT=`python test/pep8.py --filename '*.py,*.py.in' --ignore W . | wc -l`

--- a/test/travis-build
+++ b/test/travis-build
@@ -2,7 +2,7 @@
 
 # Limits as of February 2, 2017
 ERROR_LIMIT=2898
-WARNING_LIMIT=62
+WARNING_LIMIT=46
 
 RESULT=0
 ERROR_COUNT=`python test/pep8.py --filename '*.py,*.py.in' --ignore W . | wc -l`

--- a/tools/CH_constants.py
+++ b/tools/CH_constants.py
@@ -69,7 +69,7 @@ field_mapping = {
     }
 
 # The externally visible data schema for services
-mandatory_fields = { 
+mandatory_fields = {
     "SERVICE_URN": {"TYPE": "URN"},
     "SERVICE_URL": {"TYPE": "URL"},
     "SERVICE_CERT": {"TYPE": "CERTIFICATE"},
@@ -77,7 +77,7 @@ mandatory_fields = {
     "SERVICE_DESCRIPTION": {"TYPE" : "STRING"}
     }
 
-supplemental_fields = { 
+supplemental_fields = {
     "_GENI_SERVICE_CERT_FILENAME": {"TYPE": "STRING", "OBJECT": "SERVICE"},
     "_GENI_SERVICE_ID" : {"TYPE" : "INTEGER", "OBJECT": "SERVICE"},
     "_GENI_SERVICE_ATTRIBUTES" : {"TYPE" : "DICTIONARY", "OBJECT" : "SERVICE"},
@@ -104,5 +104,3 @@ defined_attributes = {
         "acceptable_values" : ['1', '2', '3']
         }
 }
-
-

--- a/tools/MA_constants.py
+++ b/tools/MA_constants.py
@@ -1,24 +1,24 @@
-#----------------------------------------------------------------------         
+#----------------------------------------------------------------------
 # Copyright (c) 2011-2016 Raytheon BBN Technologies
-#                                                                               
-# Permission is hereby granted, free of charge, to any person obtaining         
-# a copy of this software and/or hardware specification (the "Work") to         
-# deal in the Work without restriction, including without limitation the        
-# rights to use, copy, modify, merge, publish, distribute, sublicense,          
-# and/or sell copies of the Work, and to permit persons to whom the Work        
-# is furnished to do so, subject to the following conditions:                   
-#                                                                               
-# The above copyright notice and this permission notice shall be                
-# included in all copies or substantial portions of the Work.                   
-#                                                                               
-# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS           
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF                    
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND                         
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT                   
-# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,                  
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,            
-# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS            
-# IN THE WORK.                                                                  
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and/or hardware specification (the "Work") to
+# deal in the Work without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Work, and to permit persons to whom the Work
+# is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Work.
+#
+# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+# IN THE WORK.
 #----------------------------------------------------------------------
 
 credential_types = [
@@ -77,14 +77,14 @@ optional_fields = {
 
 standard_plus_optional = dict(standard_fields.items() + optional_fields.items())
 
-standard_key_fields = { 
+standard_key_fields = {
     "KEY_MEMBER" : {"TYPE" : "URN", "CREATE" : "REQUIRED"}, \
     "KEY_ID" : {"TYPE" : "STRING"}, \
     "KEY_TYPE" : {"TYPE" : "STRING", "CREATE" : "ALLOWED"}, \
     "KEY_PUBLIC" : {"TYPE" : "KEY", "CREATE" : "REQUIRED"},  \
     "KEY_PRIVATE" : {"TYPE" : "KEY", "CREATE" : "ALLOWED"}, \
     "KEY_DESCRIPTION" : \
-         {"TYPE" : "STRING", "CREATE" : "ALLOWED", "UPDATE" : True} 
+         {"TYPE" : "STRING", "CREATE" : "ALLOWED", "UPDATE" : True}
 }
 
 optional_key_fields = {
@@ -128,7 +128,7 @@ field_mapping = {
 }
 
 key_fields = ["KEY_MEMBER", "KEY_ID", "KEY_PUBLIC", "KEY_PRIVATE", "KEY_TYPE",
-              "KEY_DESCRIPTION", "_GENI_KEY_MEMBER_UID", 
+              "KEY_DESCRIPTION", "_GENI_KEY_MEMBER_UID",
               "_GENI_KEY_FILENAME" ]
 
 key_field_mapping = {
@@ -149,10 +149,10 @@ attributes = [
     "MEMBER_URN", "MEMBER_UID", "MEMBER_FIRSTNAME", "MEMBER_LASTNAME",
     "MEMBER_USERNAME", "MEMBER_EMAIL", "_GENI_MEMBER_DISPLAYNAME",
     "_GENI_MEMBER_PHONE_NUMBER", "_GENI_MEMBER_AFFILIATION",
-    "_GENI_MEMBER_EPPN", "KEY_MEMBER", "KEY_ID", 
+    "_GENI_MEMBER_EPPN", "KEY_MEMBER", "KEY_ID",
     "KEY_PUBLIC", "KEY_PRIVATE", "KEY_TYPE",
     "KEY_DESCRIPTION", "_GENI_KEY_MEMBER_UID", "_GENI_KEY_FILENAME",
-    "_GENI_MEMBER_ENABLED", "_GENI_ENABLE_WIMAX", "_GENI_ENABLE_WIMAX_BUTTON", 
+    "_GENI_MEMBER_ENABLED", "_GENI_ENABLE_WIMAX", "_GENI_ENABLE_WIMAX_BUTTON",
     "_GENI_ENABLE_IRODS", "_GENI_IRODS_USERNAME", "_GENI_WIMAX_USERNAME",
     "_GENI_MEMBER_URL", "_GENI_MEMBER_REASON", "_GENI_MEMBER_REFERENCE"
 ]
@@ -194,4 +194,3 @@ updatable_key_fields = ["KEY_DESCRIPTION", "_GENI_KEY_FILENAME"]
 
 USER_CRED_LIFE_YEARS = 1 # See MA.get_user_credential
 # FIXME: username regex
-

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -20,4 +20,3 @@
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
 #----------------------------------------------------------------------
-

--- a/tools/cert_utils.py
+++ b/tools/cert_utils.py
@@ -172,7 +172,7 @@ def make_cert(uuid, email, urn, signer_cert_file, signer_key_file, csr_file,
         "authorityKeyIdentifier=keyid:always,issuer:always\n" + \
         "basicConstraints = CA:false\n"
     extdata = extdata_template % extname
-        
+
     if email:
         extdata = extdata + \
             "subjectAltName=email:copy,URI:%s,URI:urn:uuid:%s\n" \

--- a/tools/chapi_log.py
+++ b/tools/chapi_log.py
@@ -21,7 +21,7 @@
 # IN THE WORK.
 #----------------------------------------------------------------------
 
-# Methods to provide standard logging within CHAPI for 
+# Methods to provide standard logging within CHAPI for
 # invocations, errors, exceptions and other information events
 
 # In this way, the handling of CHAPI messages (what level, to what
@@ -160,4 +160,3 @@ def chapi_log_result(prefix, method, result, extra=None):
     if verboseObj.isVerbose():
         # Send to syslog at INFO level
         chapi_audit(prefix, msg, logging.INFO, extra=extra)
-

--- a/tools/chapi_scaling.py
+++ b/tools/chapi_scaling.py
@@ -29,7 +29,7 @@ import tempfile
 import time
 
 class ScalingTester:
-    def __init__(self, url, object_file, user_file, 
+    def __init__(self, url, object_file, user_file,
                  match_field, filter_fields, method, client_location):
         self._url = url
         self._method = method
@@ -42,21 +42,21 @@ class ScalingTester:
         self._options_file = self._generateOptionsFile()
         self._users = self._parseUsers()
 
-    def _parseObjectIDs(self): 
+    def _parseObjectIDs(self):
         ids_raw = open(self._object_file).read()
         ids = ids_raw.split('\n')
         return [id.strip() for id in ids if len(id.strip()) > 0]
 
-    def _parseUsers(self): 
+    def _parseUsers(self):
         users_raw = open(self._user_file).read()
         return json.loads(users_raw)
-    
+
     def _parseFilterFields(self, filter_fields):
         if not filter_fields: return None
         return [ff.strip() for ff in filter_fields.split(',')]
 
     # Make an options file for querying all objects by ID by field
-    def _generateOptionsFile(self): 
+    def _generateOptionsFile(self):
         (fd, filename) = tempfile.mkstemp()
         os.close(fd)
         options = {'match' : {self._match_field : self._object_ids}}
@@ -75,7 +75,7 @@ class ScalingTester:
             user_cert = self._users[user_index]['cert']
             user_key = self._users[user_index]['key']
 #            print "CERT = %s KEY = %s" % (user_cert, user_key)
-        
+
             command_template = "time (python %s --key %s --cert %s " + \
                 "--options_file %s --method %s --url %s 2&>1 > /dev/null) &\n"
             command =  command_template % \
@@ -90,10 +90,10 @@ class ScalingTester:
             [line for line in output.split('\n') if line.startswith('real')]
         real_timing = [rt.split('\t')[1] for rt in real_timing_raw]
         secs = [self.parseTime(rt) for rt in real_timing]
-        mean = 0; 
+        mean = 0;
         for sec in secs: mean = mean + sec
         mean = mean / num_concurrent
-        print "Mean  %s : %s" % (mean, secs) 
+        print "Mean  %s : %s" % (mean, secs)
 
     def run_script(self, script_filename):
         run_script_command = ["/bin/bash", script_filename]
@@ -108,7 +108,7 @@ class ScalingTester:
 
     def parseTime(self, time_min_sec):
         parts = time_min_sec.split('m')
-        min = int(parts[0]) 
+        min = int(parts[0])
         sec = float(parts[1].split('s')[0])
         sec = 60*min + sec
         return sec
@@ -117,22 +117,22 @@ def parseOptions(args):
     parser = optparse.OptionParser()
     parser.add_option("--url", help="URL of service to which to connect",
                       default=None)
-    parser.add_option("--object_file", 
-                      help="File containing list of object IDs", 
+    parser.add_option("--object_file",
+                      help="File containing list of object IDs",
                       default=None)
-    parser.add_option("--user_file", 
+    parser.add_option("--user_file",
                       help="JSON File containing list {cert, key} dicts",
                       default=None)
-    parser.add_option("--method", 
+    parser.add_option("--method",
                       help="Name of method to invoke",
                       default='lookup_slices')
-    parser.add_option("--match_field", help="Name of object field to match", 
+    parser.add_option("--match_field", help="Name of object field to match",
                       default="SLICE_UID")
     parser.add_option("--filter_fields", help="List of object fields to select",
                       default=None)
     parser.add_option("--client_location", help="Location of client.py",
                       default = "client.py")
-    parser.add_option("--num_concurrent", 
+    parser.add_option("--num_concurrent",
                       help="Number concurrent calls", default=1)
     parser.add_option("--frequency", help='Time to wait between invocations',
                       default=5)
@@ -145,8 +145,8 @@ def parseOptions(args):
         sys.exit(0)
 
     return opts
-     
-     
+
+
 def main(args = sys.argv):
     opts = parseOptions(args)
     st = ScalingTester(opts.url, opts.object_file, opts.user_file, \
@@ -158,9 +158,7 @@ def main(args = sys.argv):
         st.invoke(int(opts.num_concurrent))
         if iter < num_iters-1:
             time.sleep(int(opts.frequency))
-    
+
 
 if __name__ == "__main__":
     sys.exit(main())
-    
-    

--- a/tools/cs_utils.py
+++ b/tools/cs_utils.py
@@ -32,6 +32,3 @@ def add_attribute(db, session, signer, principal, attribute, context_type, conte
 # Obsolete: CS_ASSERTION table no longer supported
 def delete_attribute(db, session, principal, context_type, context):
     pass
-
-
-

--- a/tools/dbtest.py
+++ b/tools/dbtest.py
@@ -35,7 +35,7 @@ def services_test(db):
         print str(k)
 
     import pdb; pdb.set_trace()
-    
+
     stmt = services.query('service_urn', 'service_url')
     rs = stmt.execute()
     for row in rs:
@@ -57,7 +57,7 @@ def slice_test(db):
     q = q.filter(SLICE_TABLE.c.slice_urn == urn)
     rows = q.all()
     session.close()
-    for row in rows: 
+    for row in rows:
         print "ROW = " + str(row.slice_urn) + " " + \
             str(row.project_id)  + " " + str(row.expiration) + " " + \
             str(row.project_name) + " " + \

--- a/tools/file_checker.py
+++ b/tools/file_checker.py
@@ -27,7 +27,7 @@ import threading
 import time
 
 # Simple threaded base class that checks whether a particular
-# file has changed and calls the base class method handeFileChange 
+# file has changed and calls the base class method handeFileChange
 # when it has changed (based on change to OS file modified time
 class FileChecker(threading.Thread):
     def __init__(self, filename, interval):
@@ -38,7 +38,7 @@ class FileChecker(threading.Thread):
         self._running = False
 
     # Thread 'run' method: Loop and check if the file modify time has
-    # changed since last time around the loop. If so, update time 
+    # changed since last time around the loop. If so, update time
     # and invoke handleFileChange method
     def run(self):
         self._running = True
@@ -49,13 +49,13 @@ class FileChecker(threading.Thread):
                 self._file_time = new_file_time
                 self.handleFileChange()
 
-    # Base method called 
+    # Base method called
     def handleFileChange(self):
         print "File changed: %s %s" % (self._filename, self._file_time)
 
     # Kill the searching thread, to drop out of the 'run' loop after next sleep
     def stop(self): self._running = False
-        
+
 # Simple test program: Runs for 50 seconds, counting the seconds
 # And spawning a FileChecker to check on /tmp/foo.txt
 def main():
@@ -77,4 +77,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/tools/geni_constants.py
+++ b/tools/geni_constants.py
@@ -21,7 +21,7 @@
 # IN THE WORK.
 #----------------------------------------------------------------------
 
-# Sets of constants for defining relationships and roles in GENI 
+# Sets of constants for defining relationships and roles in GENI
 # Registry and Authorities
 
 # Context Types
@@ -32,7 +32,7 @@ SERVICE_CONTEXT = 4
 MEMBER_CONTEXT = 5
 
 # For translating context types to names (if stored that way in database)
-context_type_names = {PROJECT_CONTEXT : "PROJECT", SLICE_CONTEXT : "SLICE", 
+context_type_names = {PROJECT_CONTEXT : "PROJECT", SLICE_CONTEXT : "SLICE",
                       RESOURCE_CONTEXT : "RESOURCE", SERVICE_CONTEXT : "SERVICE",
                       MEMBER_CONTEXT : "MEMBER"}
 
@@ -43,7 +43,7 @@ MEMBER_ATTRIBUTE = 3
 AUDITOR_ATTRIBUTE = 4
 OPERATOR_ATTRIBUTE = 5
 
-attribute_type_names = { LEAD_ATTRIBUTE : "LEAD", ADMIN_ATTRIBUTE : "ADMIN", 
+attribute_type_names = { LEAD_ATTRIBUTE : "LEAD", ADMIN_ATTRIBUTE : "ADMIN",
                          MEMBER_ATTRIBUTE : "MEMBER", AUDITOR_ATTRIBUTE : "AUDITOR",
                          OPERATOR_ATTRIBUTE : "OPERATOR"}
 

--- a/tools/manage_service_attributes.py
+++ b/tools/manage_service_attributes.py
@@ -22,7 +22,7 @@
 #----------------------------------------------------------------------
 
 # A tool to add/remove attributes to service entries
-# Check that the name and value are valid as defined in the 
+# Check that the name and value are valid as defined in the
 # CH_constants.defined_attfibutes
 
 import CH_constants as CH
@@ -128,4 +128,3 @@ def validate_name_value(name, value, service_type):
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/tools/mapped_tables.py
+++ b/tools/mapped_tables.py
@@ -1,24 +1,24 @@
-#----------------------------------------------------------------------         
+#----------------------------------------------------------------------
 # Copyright (c) 2011-2016 Raytheon BBN Technologies
-#                                                                               
-# Permission is hereby granted, free of charge, to any person obtaining         
-# a copy of this software and/or hardware specification (the "Work") to         
-# deal in the Work without restriction, including without limitation the        
-# rights to use, copy, modify, merge, publish, distribute, sublicense,          
-# and/or sell copies of the Work, and to permit persons to whom the Work        
-# is furnished to do so, subject to the following conditions:                   
-#                                                                               
-# The above copyright notice and this permission notice shall be                
-# included in all copies or substantial portions of the Work.                   
-#                                                                               
-# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS           
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF                    
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND                         
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT                   
-# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,                  
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,            
-# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS            
-# IN THE WORK.                                                                  
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and/or hardware specification (the "Work") to
+# deal in the Work without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Work, and to permit persons to whom the Work
+# is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Work.
+#
+# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+# IN THE WORK.
 #----------------------------------------------------------------------
 
 class MemberAttribute(object):
@@ -28,4 +28,3 @@ class MemberAttribute(object):
         self.member_id = member_id
         self.self_asserted = self_asserted
         #self.logging_service = pm.getService('loggingv1handler')
-

--- a/tools/pluginmanager.py
+++ b/tools/pluginmanager.py
@@ -78,14 +78,14 @@ class ConfigDB(object):
 
     def set(self, key, value):
         self._mapping[key] = value
-        
+
     def get(self, key):
         return self._mapping[key]
 
     def getAll(self):
         return self._mapping.keys()
 
-# An entry registering a REST service: 
+# An entry registering a REST service:
 #    endpoint and handler are all we really care about
 class RESTEntry(object):
     def __init__(self, endpoint, rule, handler, defaults, methods):
@@ -95,7 +95,7 @@ class RESTEntry(object):
         self._defaults = defaults
         self._methods = methods
 
-# Dispatcher for REST calls, based on 
+# Dispatcher for REST calls, based on
 class RESTDispatcher(object):
     _entries_by_endpoint = {}
 
@@ -113,7 +113,7 @@ class RESTDispatcher(object):
         pieces = endpoint.split('/')
         if len(pieces) > 2:
             key = endpoint.split('/')[1]
-        
+
             if key in self._entries_by_endpoint:
                 return self._entries_by_endpoint[key]._handler
         return None

--- a/tools/portal_client.py
+++ b/tools/portal_client.py
@@ -25,7 +25,7 @@ from gcf.omnilib.util.dossl import _do_ssl
 import xmlrpclib
 from gcf.omnilib.frameworks.framework_base import Framework_Base
 
-# Emulate CHAPI traffic supporting specific portal pages: 
+# Emulate CHAPI traffic supporting specific portal pages:
 # e.g. home, projects, slices
 
 class MAClientFramework(Framework_Base):
@@ -56,23 +56,23 @@ def emulate_portal_page(opts, verbose = False):
         print "Fetching home page for %s" % opts.eppn
         # Lookup public member info by EPPN
         client_options = {'match' : {'_GENI_MEMBER_EPPN' : opts.eppn}}
-        (public_info, msg) = _do_ssl(framework, suppress_errors, reason, 
-                                     ma_client.lookup_public_member_info, 
+        (public_info, msg) = _do_ssl(framework, suppress_errors, reason,
+                                     ma_client.lookup_public_member_info,
                                      opts.credentials, client_options)
         member_urn = public_info['value'].keys()[0]
         member_uid = public_info['value'][member_urn]['MEMBER_UID']
 
         # Lookup identifying info by UID
         client_options = {'match' : {'MEMBER_UID': [member_uid]}}
-        (identifying_info, msg) = _do_ssl(framework, suppress_errors, reason, 
-                                          ma_client.lookup_identifying_member_info, 
+        (identifying_info, msg) = _do_ssl(framework, suppress_errors, reason,
+                                          ma_client.lookup_identifying_member_info,
                                           opts.credentials, client_options)
 
         # Lookup private key by UID
-        client_options = {'match' : {'MEMBER_UID': [member_uid]}, 
+        client_options = {'match' : {'MEMBER_UID': [member_uid]},
                           'filter' : ['_GENI_MEMBER_INSIDE_PRIVATE_KEY']}
-        (private_info, msg) = _do_ssl(framework, suppress_errors, reason, 
-                                      ma_client.lookup_private_member_info, 
+        (private_info, msg) = _do_ssl(framework, suppress_errors, reason,
+                                      ma_client.lookup_private_member_info,
                                       opts.credentials, client_options)
         if verbose:
             print "Result = %s " % public_info
@@ -82,26 +82,26 @@ def emulate_portal_page(opts, verbose = False):
         # Lookup public inside cert by UID
         client_options = {'match' : {'MEMBER_UID' : [member_uid]},
                           'filter' : ['_GENI_MEMBER_INSIDE_CERTIFICATE']}
-        (public_info, msg) = _do_ssl(framework, suppress_errors, reason, 
-                                      ma_client.lookup_public_member_info, 
+        (public_info, msg) = _do_ssl(framework, suppress_errors, reason,
+                                      ma_client.lookup_public_member_info,
                                       opts.credentials, client_options)
         if verbose:
             print "Result = %s " % public_info
 
         # get_permissions
         client_options = {'_dummy' : ''}
-        (permissions, msg) = _do_ssl(framework, suppress_errors, reason, 
+        (permissions, msg) = _do_ssl(framework, suppress_errors, reason,
                                       cs_client.get_permissions,
-                                     member_uid, 
+                                     member_uid,
                                       opts.credentials, client_options)
         if verbose:
             print "Result = %s " % permissions
 
         # Lookup projects for member
         client_options = {'_dummy' : ''}
-        (projects_info, msg) = _do_ssl(framework, suppress_errors, reason, 
+        (projects_info, msg) = _do_ssl(framework, suppress_errors, reason,
                                        sa_client.lookup_projects_for_member,
-                                       member_urn, 
+                                       member_urn,
                                        opts.credentials, client_options)
         if verbose:
             print "Result = %s " % projects_info
@@ -111,7 +111,7 @@ def emulate_portal_page(opts, verbose = False):
                             for project_info in projects_info['value']
                         if not project_info['EXPIRED']]
         client_options = {'match' : {'PROJECT_UID' : project_uids}}
-        (projects, msg) = _do_ssl(framework, suppress_errors, reason, 
+        (projects, msg) = _do_ssl(framework, suppress_errors, reason,
                                        sa_client.lookup_projects,
                                        opts.credentials, client_options)
         if verbose:
@@ -119,9 +119,9 @@ def emulate_portal_page(opts, verbose = False):
 
         # Lookup slices for member
         client_options = {'_dummy' : ''}
-        (slices_info, msg) = _do_ssl(framework, suppress_errors, reason, 
+        (slices_info, msg) = _do_ssl(framework, suppress_errors, reason,
                                        sa_client.lookup_slices_for_member,
-                                       member_urn, 
+                                       member_urn,
                                        opts.credentials, client_options)
         if verbose:
             print "Result = %s " % slices_info
@@ -131,7 +131,7 @@ def emulate_portal_page(opts, verbose = False):
                             for slice_info in slices_info['value']
                       if not slice_info['EXPIRED']]
         client_options = {'match' : {'SLICE_UID' : slice_uids}}
-        (slices, msg) = _do_ssl(framework, suppress_errors, reason, 
+        (slices, msg) = _do_ssl(framework, suppress_errors, reason,
                                        sa_client.lookup_slices,
                                        opts.credentials, client_options)
         if verbose:
@@ -142,24 +142,24 @@ def emulate_portal_page(opts, verbose = False):
         for slice_urn, slice_data in slices['value'].items():
             if slice_data['SLICE_EXPIRED']: continue
             slice_owner_uid = slice_data['_GENI_SLICE_OWNER']
-            if slice_owner_uid not in member_uids: 
+            if slice_owner_uid not in member_uids:
                 member_uids.append(slice_owner_uid)
         for project_urn, project_data in projects['value'].items():
             if project_data['PROJECT_EXPIRED']: continue
             project_lead_uid = project_data['_GENI_PROJECT_OWNER']
-            if project_lead_uid not in member_uids: 
+            if project_lead_uid not in member_uids:
                 member_uids.append(project_lead_uid)
         client_options = {'match' : {'MEMBER_UID' : member_uids}}
-        (members_public_info, msg) = _do_ssl(framework, suppress_errors, reason, 
+        (members_public_info, msg) = _do_ssl(framework, suppress_errors, reason,
                                        ma_client.lookup_public_member_info,
                                        opts.credentials, client_options)
         if verbose:
             print "Result = %s " % members_public_info
-        
+
         # Lookup identifying member info for all project leads, slice_owners
         client_options = {'match' : {'MEMBER_UID' : member_uids}}
-        (members_identifying_info, msg) = _do_ssl(framework, 
-                                                  suppress_errors, reason, 
+        (members_identifying_info, msg) = _do_ssl(framework,
+                                                  suppress_errors, reason,
                                                   ma_client.lookup_identifying_member_info,
                                                   opts.credentials, client_options)
         if verbose:
@@ -167,9 +167,9 @@ def emulate_portal_page(opts, verbose = False):
 
         # Lookup pending requests for user
         client_options = {'_dummy' : ''}
-        (pending_requests, msg) = _do_ssl(framework, suppress_errors, reason, 
+        (pending_requests, msg) = _do_ssl(framework, suppress_errors, reason,
                                           sa_client.get_pending_requests_for_user,
-                                          member_uid, 1, '', 
+                                          member_uid, 1, '',
                                           opts.credentials, client_options)
         if verbose:
             print "Result = %s " % pending_requests
@@ -177,8 +177,8 @@ def emulate_portal_page(opts, verbose = False):
         # Lookup identifying member info for all project leads and slice owners
         # *** Looks like we're doing this twice...
         client_options = {'match' : {'MEMBER_UID' : member_uids}}
-        (members_identifying_info, msg) = _do_ssl(framework, 
-                                                  suppress_errors, reason, 
+        (members_identifying_info, msg) = _do_ssl(framework,
+                                                  suppress_errors, reason,
                                                   ma_client.lookup_identifying_member_info,
                                                   opts.credentials, client_options)
         if verbose:
@@ -186,8 +186,8 @@ def emulate_portal_page(opts, verbose = False):
 
         # Lookup requests by user
         client_options = {'_dummy' : ''}
-        (pending_requests, msg) = _do_ssl(framework, 
-                                         suppress_errors, reason, 
+        (pending_requests, msg) = _do_ssl(framework,
+                                         suppress_errors, reason,
                                          sa_client.get_requests_by_user,
                                           member_uid, 1, '', 0,
                                          opts.credentials, client_options)
@@ -200,8 +200,8 @@ def emulate_portal_page(opts, verbose = False):
             project_uid = pending_request['context_id']
             project_uids.append(project_uid)
         client_options = {'match' : {'PROJECT_UID' : project_uids}}
-        (pending_projects, msg) = _do_ssl(framework, 
-                                         suppress_errors, reason, 
+        (pending_projects, msg) = _do_ssl(framework,
+                                         suppress_errors, reason,
                                          sa_client.lookup_projects,
                                          opts.credentials, client_options)
         if verbose:
@@ -213,28 +213,28 @@ def emulate_portal_page(opts, verbose = False):
             lead_uid = pending_project_data['_GENI_PROJECT_OWNER']
             if lead_uid not in member_uids: member_uids.append(lead_uid)
         client_options = {'match' : {'MEMBER_UID' : member_uids}}
-        (pending_project_leads, msg) = _do_ssl(framework, 
-                                         suppress_errors, reason, 
+        (pending_project_leads, msg) = _do_ssl(framework,
+                                         suppress_errors, reason,
                                          ma_client.lookup_identifying_member_info,
                                          opts.credentials, client_options)
         if verbose:
             print "Result = %s " % pending_project_leads
 
         # Lookup log entries for context
-        (log_entries, msg) = _do_ssl(framework, 
-                                     suppress_errors, reason, 
+        (log_entries, msg) = _do_ssl(framework,
+                                     suppress_errors, reason,
                                      log_client.get_log_entries_for_context,
                                      5, member_uid, 24, opts.credentials, client_options)
-            
+
         if verbose:
             print "Result = %s " % log_entries
 
         # Lookup log entries for author
-        (log_entries, msg) = _do_ssl(framework, 
-                                     suppress_errors, reason, 
+        (log_entries, msg) = _do_ssl(framework,
+                                     suppress_errors, reason,
                                      log_client.get_log_entries_by_author,
                                      member_uid, 24, opts.credentials, client_options)
-            
+
         if verbose:
             print "Result = %s " % log_entries
 
@@ -243,5 +243,3 @@ def emulate_portal_page(opts, verbose = False):
 
     else:
         print "Page not supported: %s" % page_name
-
-


### PR DESCRIPTION
Clean up ABACGuard.py and eliminate a bunch of whitespace warnings. Reduce the total count from 3398 to 2944. Still plenty of cleanup left to do.