### PR TITLE
Add support for swapping identities to support IdP changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Fix authorization for get_requests_for_context
   ([#536](https://github.com/GENI-NSF/geni-ch/issues/536))
+* Add support for swapping identities to support IdP changes
+  ([#557](https://github.com/GENI-NSF/geni-ch/issues/557))
 
 ## Installation Notes
 

--- a/etc/member_authority_policy.json
+++ b/etc/member_authority_policy.json
@@ -253,16 +253,6 @@
       ]
     },
 
-    "create_swap_id" : {
-      "__DOC__" : "self",
-       "assertions" : [
-         "ME.INVOKING_ON_$MEMBER<-CALLER"
-       ],
-      "policies" : [
-        "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
-      ]
-    },
-
     "swap_identities" : {
       "__DOC__" : "self",
        "assertions" : [

--- a/etc/member_authority_policy.json
+++ b/etc/member_authority_policy.json
@@ -28,11 +28,11 @@
      ],
      "policies" : [
        "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
-       "ME.MAY_$METHOD<-ME.IS_OPERATOR", 
+       "ME.MAY_$METHOD<-ME.IS_OPERATOR",
        "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF",
        "ME.MAY_$METHOD_$MEMBER<-ME.SHARES_PROJECT_$MEMBER",
-       "ME.MAY_$METHOD<-ME.IS_PROJECT_LEAD_AND_SEARCHING_BY_EMAIL", 
-       "ME.MAY_$METHOD<-ME.IS_PROJECT_ADMIN_AND_SEARCHING_BY_EMAIL", 
+       "ME.MAY_$METHOD<-ME.IS_PROJECT_LEAD_AND_SEARCHING_BY_EMAIL",
+       "ME.MAY_$METHOD<-ME.IS_PROJECT_ADMIN_AND_SEARCHING_BY_EMAIL",
        "ME.MAY_$METHOD<-ME.IS_SEARCHING_FOR_PROJECT_LEAD_BY_UID",
        "ME.MAY_$METHOD<-ME.HAS_PENDING_REQUEST_TO_MEMBER",
        "ME.MAY_$METHOD<-ME.HAS_PENDING_REQUEST_FROM_MEMBER"
@@ -58,11 +58,11 @@
     ],
     "policies" : [
        "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
-       "ME.MAY_$METHOD<-ME.IS_OPERATOR", 
+       "ME.MAY_$METHOD<-ME.IS_OPERATOR",
        "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF",
        "ME.MAY_$METHOD_$MEMBER<-ME.SHARES_PROJECT_$MEMBER",
-       "ME.MAY_$METHOD<-ME.IS_PROJECT_LEAD_AND_SEARCHING_BY_EMAIL", 
-       "ME.MAY_$METHOD<-ME.IS_PROJECT_ADMIN_AND_SEARCHING_BY_EMAIL", 
+       "ME.MAY_$METHOD<-ME.IS_PROJECT_LEAD_AND_SEARCHING_BY_EMAIL",
+       "ME.MAY_$METHOD<-ME.IS_PROJECT_ADMIN_AND_SEARCHING_BY_EMAIL",
        "ME.MAY_$METHOD<-ME.IS_SEARCHING_FOR_PROJECT_LEAD_BY_UID",
        "ME.MAY_$METHOD<-ME.HAS_PENDING_REQUEST_TO_MEMBER",
        "ME.MAY_$METHOD<-ME.HAS_PENDING_REQUEST_FROM_MEMBER"
@@ -75,8 +75,8 @@
        "ME.INVOKING_ON_$MEMBER<-CALLER"
      ],
     "policies" : [
-      "ME.MAY_$METHOD<-ME.IS_AUTHORITY", 
-      "ME.MAY_$METHOD<-ME.IS_OPERATOR", 
+      "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
+      "ME.MAY_$METHOD<-ME.IS_OPERATOR",
       "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
     ]
   },
@@ -87,8 +87,8 @@
        "ME.INVOKING_ON_$MEMBER<-CALLER"
      ],
     "policies" : [
-      "ME.MAY_$METHOD<-ME.IS_AUTHORITY", 
-      "ME.MAY_$METHOD<-ME.IS_OPERATOR", 
+      "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
+      "ME.MAY_$METHOD<-ME.IS_OPERATOR",
       "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
     ]
   },
@@ -99,8 +99,8 @@
        "ME.INVOKING_ON_$MEMBER<-CALLER"
      ],
     "policies" : [
-      "ME.MAY_$METHOD<-ME.IS_AUTHORITY", 
-      "ME.MAY_$METHOD<-ME.IS_OPERATOR", 
+      "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
+      "ME.MAY_$METHOD<-ME.IS_OPERATOR",
       "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
     ]
   },
@@ -111,7 +111,7 @@
        "ME.INVOKING_ON_$MEMBER<-CALLER"
      ],
     "policies" : [
-      "ME.MAY_$METHOD<-ME.IS_OPERATOR", 
+      "ME.MAY_$METHOD<-ME.IS_OPERATOR",
       "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
     ]
   },
@@ -218,7 +218,7 @@
       "policies" : [
         "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
         "ME.MAY_$METHOD<-ME.IS_OPERATOR"
-      ] 
+      ]
     },
 
     "revoke_member_privilege" : {
@@ -226,7 +226,7 @@
       "policies" : [
         "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
         "ME.MAY_$METHOD<-ME.IS_OPERATOR"
-      ] 
+      ]
     },
 
     "add_member_attribute" : {
@@ -249,6 +249,26 @@
       "policies" : [
         "ME.MAY_$METHOD<-ME.IS_AUTHORITY",
         "ME.MAY_$METHOD<-ME.IS_OPERATOR",
+        "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
+      ]
+    },
+
+    "set_swap_nonce" : {
+      "__DOC__" : "self",
+       "assertions" : [
+         "ME.INVOKING_ON_$MEMBER<-CALLER"
+       ],
+      "policies" : [
+        "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
+      ]
+    },
+
+    "swap_identities" : {
+      "__DOC__" : "self",
+       "assertions" : [
+         "ME.INVOKING_ON_$MEMBER<-CALLER"
+       ],
+      "policies" : [
         "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
       ]
     }

--- a/etc/member_authority_policy.json
+++ b/etc/member_authority_policy.json
@@ -253,7 +253,7 @@
       ]
     },
 
-    "set_swap_nonce" : {
+    "create_swap_id" : {
       "__DOC__" : "self",
        "assertions" : [
          "ME.INVOKING_ON_$MEMBER<-CALLER"

--- a/etc/member_authority_policy.json
+++ b/etc/member_authority_policy.json
@@ -269,7 +269,7 @@
          "ME.INVOKING_ON_$MEMBER<-CALLER"
        ],
       "policies" : [
-        "ME.MAY_$METHOD<-ME.INVOKING_ON_$SELF"
+        "ME.MAY_$METHOD<-ME.IS_AUTHORITY"
       ]
     }
 }

--- a/plugins/chapiv1rpc/chapi/MemberAuthority.py
+++ b/plugins/chapiv1rpc/chapi/MemberAuthority.py
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------
-# Copyright (c) 2011-2016 Raytheon BBN Technologies
+# Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -523,7 +523,9 @@ class MAv1Handler(HandlerBase):
         return mc._result
 
     def set_swap_nonce(self, member_urn, nonce, credentials, options):
-        """Remove attribute to member"""
+        """Set a swap nonce attribute on the member for later use
+        to swap identities.
+        """
         with MethodContext(self, MA_LOG_PREFIX,
                            'set_swap_nonce',
                            {'member_urn': member_urn, 'nonce': nonce},
@@ -533,6 +535,21 @@ class MAv1Handler(HandlerBase):
                     self._delegate.set_swap_nonce(mc._client_cert, member_urn,
                                                   nonce, credentials, options,
                                                   mc._session)
+        return mc._result
+
+    def swap_identities(self, member_urn, nonce, credentials, options):
+        """Swap identities by making this user point to the identity with
+        the matching nonce.
+        """
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'swap_identities',
+                           {'member_urn': member_urn, 'nonce': nonce},
+                           credentials, options, read_only=False) as mc:
+            if not mc._error:
+                mc._result = \
+                    self._delegate.swap_identities(mc._client_cert, member_urn,
+                                                   nonce, credentials, options,
+                                                   mc._session)
         return mc._result
 
 
@@ -656,4 +673,8 @@ class MAv1DelegateBase(DelegateBase):
 
     def set_swap_nonce(self, client_cert, member_urn, nonce, credentials,
                        options, session):
+        raise CHAPIv1NotImplementedError('')
+
+    def swap_identities(self, client_cert, member_urn, nonce, credentials,
+                        options, session):
         raise CHAPIv1NotImplementedError('')

--- a/plugins/chapiv1rpc/chapi/MemberAuthority.py
+++ b/plugins/chapiv1rpc/chapi/MemberAuthority.py
@@ -1,4 +1,4 @@
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -19,7 +19,7 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 import tools.pluginmanager as pm
 from DelegateBase import DelegateBase

--- a/plugins/chapiv1rpc/chapi/MemberAuthority.py
+++ b/plugins/chapiv1rpc/chapi/MemberAuthority.py
@@ -31,6 +31,7 @@ from MethodContext import *
 
 ma_logger = logging.getLogger('mav1')
 
+
 # RPC handler for Member Authority (MA) API calls
 class MAv1Handler(HandlerBase):
     def __init__(self):
@@ -50,42 +51,42 @@ class MAv1Handler(HandlerBase):
     # Generic V2 service methods
     def create(self, type, credentials, options):
         if type == "MEMBER":
-            result = \
-                self._errorReturn(CHAPIv1ArgumentError("method create not supported for MEMBER"))
+            msg = "method create not supported for MEMBER"
+            result = self._errorReturn(CHAPIv1ArgumentError(msg))
         elif type == "KEY":
             result = self.create_key(credentials, options)
         else:
-            result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
+            msg = "Invalid type: %s" % (type)
+            result = self._errorReturn(CHAPIv1ArgumentError(msg))
         return result
 
     def update(self, type, urn, credentials, options):
         if type == "MEMBER":
-            result = \
-                self.update_member_info(urn, credentials, options)
+            result = self.update_member_info(urn, credentials, options)
         elif type == "KEY":
-            result = \
-                self.update_key(urn, credentials, options)
+            result = self.update_key(urn, credentials, options)
         else:
-            result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
+            msg = "Invalid type: %s" % (type)
+            result = self._errorReturn(CHAPIv1ArgumentError(msg))
         return result
 
     def delete(self, type, urn, credentials, options):
         if type == "MEMBER":
-            result = \
-                self._errorReturn(CHAPIv1ArgumentError("method delete not supported for MEMBER"))
+            msg = "method delete not supported for MEMBER"
+            result = self._errorReturn(CHAPIv1ArgumentError(msg))
         elif type == "KEY":
-            result = \
-                self.delete_key( urn, credentials, options)
+            result = self.delete_key(urn, credentials, options)
         else:
-             result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
+            msg = "Invalid type: %s" % (type)
+            result = self._errorReturn(CHAPIv1ArgumentError(msg))
         return result
 
     def lookup(self, type, credentials, options):
         if not isinstance(options, dict):
-            return self._errorReturn(CHAPIv1ArgumentError("Options argument must be dictionary"))
+            msg = "Options argument must be dictionary"
+            return self._errorReturn(CHAPIv1ArgumentError(msg))
         if type == "MEMBER":
-            result = \
-                self.lookup_allowed_member_info(credentials, options)
+            result = self.lookup_allowed_member_info(credentials, options)
         elif type == "KEY":
             # In v1 we return a dictionary (indexed by member URN)
             # of a list of dictionaries, one for each key of that user
@@ -98,20 +99,20 @@ class MAv1Handler(HandlerBase):
                 self.lookup_keys(credentials, options)
             if result['code'] == NO_ERROR:
                 v2_result = {}
-#                chapi_info("LOOKUP", "RESULT = %s" % result)
+                # chapi_info("LOOKUP", "RESULT = %s" % result)
                 for member_urn, key_infos in result['value'].items():
                     for key_info in key_infos:
-#                        chapi_info("LOOKUP", "MURN = %s KEY_INFO = %s" % \
-#                                       (member_urn, key_info))
+                        # chapi_info("LOOKUP", "MURN = %s KEY_INFO = %s" % \
+                        #            (member_urn, key_info))
                         if 'KEY_MEMBER' not in key_info:
                             key_info['KEY_MEMBER'] = member_urn
                         key_id = key_info['KEY_ID']
                         v2_result[key_id] = key_info
                 result = self._successReturn(v2_result)
         else:
-            result = self._errorReturn(CHAPIv1ArgumentError("Invalid type: %s" % type))
+            msg = "Invalid type: %s" % (type)
+            result = self._errorReturn(CHAPIv1ArgumentError(msg))
         return result
-
 
     # MEMBER service methods
 
@@ -119,10 +120,11 @@ class MAv1Handler(HandlerBase):
         with MethodContext(self, MA_LOG_PREFIX, 'lookup_allowed_member_info',
                            {}, credentials, options, read_only=True) as mc:
             if not mc._error:
-                mc._result = self._delegate.lookup_allowed_member_info(mc._client_cert,
-                                                                       credentials,
-                                                                       options,
-                                                                       mc._session)
+                mc._result = \
+                    self._delegate.lookup_allowed_member_info(mc._client_cert,
+                                                              credentials,
+                                                              options,
+                                                              mc._session)
         return mc._result
 
     def lookup_public_member_info(self, credentials, options):
@@ -177,8 +179,8 @@ class MAv1Handler(HandlerBase):
         return mc._result
 
     def lookup_public_identifying_member_info(self, credentials, options):
-        """Return both public and identifying information about members specified in options
-        filter and query fields
+        """Return both public and identifying information about members
+        specified in options filter and query fields
 
         This call is protected
         Authorized by client cert and credentials
@@ -189,9 +191,9 @@ class MAv1Handler(HandlerBase):
             if not mc._error:
                 mc._result = \
                     self._delegate.lookup_public_identifying_member_info(mc._client_cert,
-                                                                  credentials,
-                                                                  options,
-                                                                  mc._session)
+                                                                         credentials,
+                                                                         options,
+                                                                         mc._session)
         return mc._result
 
     def lookup_login_info(self, credentials, options):
@@ -219,7 +221,7 @@ class MAv1Handler(HandlerBase):
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'get_credentials',
-                           {'member_urn' : member_urn},
+                           {'member_urn': member_urn},
                            credentials, options, read_only=True) as mc:
             if not mc._error:
                 mc._result = \
@@ -238,7 +240,7 @@ class MAv1Handler(HandlerBase):
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'update_member_info',
-                           {'member_urn' : member_urn},
+                           {'member_urn': member_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -250,16 +252,16 @@ class MAv1Handler(HandlerBase):
         return mc._result
 
     def create_member(self, attributes, credentials, options):
-        """Create a new member using the specified attributes.  Attribute email is
-        required.  Returns the attributes of the resulting member record, including
-        the uid and urn.
+        """Create a new member using the specified attributes.  Attribute
+        email is required.  Returns the attributes of the resulting member
+        record, including the uid and urn.
 
         This call is protected
         Authorized by client cert and credentials
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'create_member',
-                           {'attributes' : attributes},
+                           {'attributes': attributes},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -276,7 +278,8 @@ class MAv1Handler(HandlerBase):
         """Create a record for a key pair for given member
         Arguments:
             member_urn: URN of member for which to retrieve credentials
-            options: 'fields' containing the fields for the key pair being stored
+            options: 'fields' containing the fields for the key pair being
+                     stored
         Return:
             Dictionary of name/value pairs for created key record
             including the KEY_ID
@@ -297,7 +300,8 @@ class MAv1Handler(HandlerBase):
     def delete_key(self, key_id, credentials, options):
         """Delete a specific key pair for given member
         Arguments:
-            key_id: KEY_ID (unique for member/key fingerprint) of key(s) to be deleted
+            key_id: KEY_ID (unique for member/key fingerprint) of key(s) to
+                    be deleted
         Return:
             True if succeeded
 
@@ -305,7 +309,7 @@ class MAv1Handler(HandlerBase):
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'delete_key',
-                           {'key_id' : key_id},
+                           {'key_id': key_id},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -331,7 +335,7 @@ class MAv1Handler(HandlerBase):
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'update_key',
-                           {'key_id' : key_id},
+                           {'key_id': key_id},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -359,9 +363,9 @@ class MAv1Handler(HandlerBase):
             if not mc._error:
                 mc._result = \
                     self._delegate.lookup_keys(mc._client_cert,
-                                              credentials,
-                                              options,
-                                              mc._session)
+                                               credentials,
+                                               options,
+                                               mc._session)
         return mc._result
 
     def create_certificate(self, member_urn, credentials, options):
@@ -371,15 +375,15 @@ class MAv1Handler(HandlerBase):
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'create_certificate',
-                           {'member_urn' : member_urn},
+                           {'member_urn': member_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
                     self._delegate.create_certificate(mc._client_cert,
-                                              member_urn,
-                                              credentials,
-                                              options,
-                                              mc._session)
+                                                      member_urn,
+                                                      credentials,
+                                                      options,
+                                                      mc._session)
         return mc._result
 
     # ClientAuth API
@@ -399,7 +403,7 @@ class MAv1Handler(HandlerBase):
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'list_authorized_clients',
-                           {'member_id' : member_id}, [], {},
+                           {'member_id': member_id}, [], {},
                            read_only=True) as mc:
             if not mc._error:
                 mc._result = \
@@ -413,8 +417,9 @@ class MAv1Handler(HandlerBase):
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'authorize_client',
-                           {'member_id' : member_id,'client_urn' : client_urn,
-                            'authorize_sense' : authorize_sense},
+                           {'member_id': member_id,
+                            'client_urn': client_urn,
+                            'authorize_sense': authorize_sense},
                            [], {}, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -425,7 +430,6 @@ class MAv1Handler(HandlerBase):
                                                     mc._session)
         return mc._result
 
-
     # member disable API
     def enable_user(self, member_urn, enable_sense, credentials, options):
         """Enable or disable a user based on URN. If enable_sense is False, then user
@@ -433,8 +437,8 @@ class MAv1Handler(HandlerBase):
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'enable_user',
-                           {'member_urn' : member_urn,
-                            'enable_sense' : enable_sense},
+                           {'member_urn': member_urn,
+                            'enable_sense': enable_sense},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -447,13 +451,14 @@ class MAv1Handler(HandlerBase):
         return mc._result
 
     # member privilege (private)
-    def add_member_privilege(self, member_uid, privilege, credentials, options):
+    def add_member_privilege(self, member_uid, privilege, credentials,
+                             options):
         """Add a privilege to a member.
         privilege is either OPERATOR or PROJECT_LEAD
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'add_member_privilege',
-                           {'member_uid' : member_uid,'privilege' : privilege},
+                           {'member_uid': member_uid, 'privilege': privilege},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -465,11 +470,12 @@ class MAv1Handler(HandlerBase):
                                                         mc._session)
         return mc._result
 
-    def revoke_member_privilege(self, member_uid, privilege, credentials, options):
+    def revoke_member_privilege(self, member_uid, privilege, credentials,
+                                options):
         """Revoke a privilege for a member."""
         with MethodContext(self, MA_LOG_PREFIX,
                            'revoke_member_privilege',
-                           {'member_uid' : member_uid,'privilege' : privilege},
+                           {'member_uid': member_uid, 'privilege': privilege},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -487,9 +493,9 @@ class MAv1Handler(HandlerBase):
         """Add an attribute to member"""
         with MethodContext(self, MA_LOG_PREFIX,
                            'add_member_attribute',
-                           {'member_urn' : member_urn,
-                            'name' : name, 'value' : value,
-                            'self_asserted' : self_asserted},
+                           {'member_urn': member_urn,
+                            'name': name, 'value': value,
+                            'self_asserted': self_asserted},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
@@ -509,17 +515,17 @@ class MAv1Handler(HandlerBase):
         """Remove attribute to member"""
         with MethodContext(self, MA_LOG_PREFIX,
                            'remove_member_attribute',
-                           {'member_urn' : member_urn, 'name' : name,
-                            'value' : value},
+                           {'member_urn': member_urn, 'name': name,
+                            'value': value},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
                     self._delegate.remove_member_attribute(mc._client_cert,
-                                                        member_urn,
-                                                        name,
-                                                        credentials,
-                                                        options,
-                                                        mc._session, value)
+                                                           member_urn,
+                                                           name,
+                                                           credentials,
+                                                           options,
+                                                           mc._session, value)
         return mc._result
 
     def create_swap_id(self, member_urn, credentials, options):

--- a/plugins/chapiv1rpc/chapi/MemberAuthority.py
+++ b/plugins/chapiv1rpc/chapi/MemberAuthority.py
@@ -522,18 +522,18 @@ class MAv1Handler(HandlerBase):
                                                         mc._session, value)
         return mc._result
 
-    def set_swap_nonce(self, member_urn, nonce, credentials, options):
+    def create_swap_id(self, member_urn, credentials, options):
         """Set a swap nonce attribute on the member for later use
         to swap identities.
         """
         with MethodContext(self, MA_LOG_PREFIX,
-                           'set_swap_nonce',
-                           {'member_urn': member_urn, 'nonce': nonce},
+                           'create_swap_id',
+                           {'member_urn': member_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.set_swap_nonce(mc._client_cert, member_urn,
-                                                  nonce, credentials, options,
+                    self._delegate.create_swap_id(mc._client_cert, member_urn,
+                                                  credentials, options,
                                                   mc._session)
         return mc._result
 
@@ -671,8 +671,8 @@ class MAv1DelegateBase(DelegateBase):
                                     credentials, options, session, att_value=None):
         raise CHAPIv1NotImplementedError('')
 
-    def set_swap_nonce(self, client_cert, member_urn, nonce, credentials,
-                       options, session):
+    def create_swap_id(self, client_cert, member_urn, credentials, options,
+                       session):
         raise CHAPIv1NotImplementedError('')
 
     def swap_identities(self, client_cert, member_urn, nonce, credentials,

--- a/plugins/chapiv1rpc/chapi/MemberAuthority.py
+++ b/plugins/chapiv1rpc/chapi/MemberAuthority.py
@@ -528,34 +528,19 @@ class MAv1Handler(HandlerBase):
                                                            mc._session, value)
         return mc._result
 
-    def create_swap_id(self, member_urn, credentials, options):
-        """Set a swap nonce attribute on the member for later use
-        to swap identities.
-        """
-        with MethodContext(self, MA_LOG_PREFIX,
-                           'create_swap_id',
-                           {'member_urn': member_urn},
-                           credentials, options, read_only=False) as mc:
-            if not mc._error:
-                mc._result = \
-                    self._delegate.create_swap_id(mc._client_cert, member_urn,
-                                                  credentials, options,
-                                                  mc._session)
-        return mc._result
-
-    def swap_identities(self, member_urn, nonce, credentials, options):
+    def swap_identities(self, source_urn, dest_urn, credentials, options):
         """Swap identities by making this user point to the identity with
         the matching nonce.
         """
         with MethodContext(self, MA_LOG_PREFIX,
                            'swap_identities',
-                           {'member_urn': member_urn, 'nonce': nonce},
+                           {'source_urn': source_urn, 'dest_urn': dest_urn},
                            credentials, options, read_only=False) as mc:
             if not mc._error:
                 mc._result = \
-                    self._delegate.swap_identities(mc._client_cert, member_urn,
-                                                   nonce, credentials, options,
-                                                   mc._session)
+                    self._delegate.swap_identities(mc._client_cert, source_urn,
+                                                   dest_urn, credentials,
+                                                   options, mc._session)
         return mc._result
 
 
@@ -677,10 +662,6 @@ class MAv1DelegateBase(DelegateBase):
                                     credentials, options, session, att_value=None):
         raise CHAPIv1NotImplementedError('')
 
-    def create_swap_id(self, client_cert, member_urn, credentials, options,
-                       session):
-        raise CHAPIv1NotImplementedError('')
-
-    def swap_identities(self, client_cert, member_urn, nonce, credentials,
+    def swap_identities(self, client_cert, source_urn, dest_urn, credentials,
                         options, session):
         raise CHAPIv1NotImplementedError('')

--- a/plugins/chapiv1rpc/chapi/MemberAuthority.py
+++ b/plugins/chapiv1rpc/chapi/MemberAuthority.py
@@ -522,6 +522,19 @@ class MAv1Handler(HandlerBase):
                                                         mc._session, value)
         return mc._result
 
+    def set_swap_nonce(self, member_urn, nonce, credentials, options):
+        """Remove attribute to member"""
+        with MethodContext(self, MA_LOG_PREFIX,
+                           'set_swap_nonce',
+                           {'member_urn': member_urn, 'nonce': nonce},
+                           credentials, options, read_only=False) as mc:
+            if not mc._error:
+                mc._result = \
+                    self._delegate.set_swap_nonce(mc._client_cert, member_urn,
+                                                  nonce, credentials, options,
+                                                  mc._session)
+        return mc._result
+
 
 # Base class for implementations of MA API
 # Must be  implemented in a derived class, and that derived class
@@ -639,4 +652,8 @@ class MAv1DelegateBase(DelegateBase):
 
     def remove_member_attribute(self, client_cert, member_urn, att_name, \
                                     credentials, options, session, att_value=None):
+        raise CHAPIv1NotImplementedError('')
+
+    def set_swap_nonce(self, client_cert, member_urn, nonce, credentials,
+                       options, session):
         raise CHAPIv1NotImplementedError('')

--- a/plugins/marm/MAv1Implementation.py
+++ b/plugins/marm/MAv1Implementation.py
@@ -1776,7 +1776,7 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
         session.add(ts_attr)
         return self._successReturn(nonce)
 
-    def swap_identities(self, client_cert, member_urn, nonce, credentials,
+    def swap_identities(self, client_cert, source_urn, dest_urn, credentials,
                         options, session):
         """Swaps two identities by swapping their ePPNs. Will
         also swap the email addresses if they differ.
@@ -1790,13 +1790,13 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
         occurred.
         """
         # find the uid
-        dest = self._get_first_attr(session, None, MA.MEMBER_URN, member_urn)
+        dest = self._get_first_attr(session, None, MA.MEMBER_URN, dest_urn)
         if not dest:
-            raise CHAPIv1ArgumentError('No member with URN ' + member_urn)
+            raise CHAPIv1ArgumentError('No member with URN ' + dest_urn)
 
-        source = self._get_first_attr(session, None, MA.SWAP_ID_ATTR, nonce)
+        source = self._get_first_attr(session, None, MA.MEMBER_URN, source_urn)
         if not source:
-            raise CHAPIv1ArgumentError('Invalid swap tag ' + nonce)
+            raise CHAPIv1ArgumentError('No member with URN ' + source_urn)
 
         dest_eppn = self._get_first_attr(session, dest.member_id,
                                          MA.MEMBER_EPPN)
@@ -1806,8 +1806,6 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
                                            MA.MEMBER_EPPN)
         source_email = self._get_first_attr(session, source.member_id,
                                             MA.MEMBER_EMAIL)
-        source_urn = self._get_first_attr(session, source.member_id,
-                                          MA.MEMBER_URN)
 
         # Swap the EPPNS
         tmp = dest_eppn.value
@@ -1825,12 +1823,8 @@ Please see http://groups.geni.net/geni/wiki/ProjectLeadWelcome for information o
         ts = datetime.datetime.utcnow().replace(microsecond=0)
         ts_attr = MemberAttribute(MA.SWAP_TS_ATTR, ts, dest.member_id, False)
         session.add(ts_attr)
-        from_attr = MemberAttribute(MA.SWAP_FROM_ATTR, source_urn.value,
+        from_attr = MemberAttribute(MA.SWAP_FROM_ATTR, source_urn,
                                     dest.member_id, False)
         session.add(from_attr)
-
-        # Can we clear the NONCE and NONCE_TS from the source account?
-        self._delete_attr(session, source.member_id, MA.SWAP_ID_ATTR, nonce)
-        self._delete_attr(session, source.member_id, MA.SWAP_TS_ATTR)
 
         return self._successReturn(True)

--- a/test/travis-build
+++ b/test/travis-build
@@ -11,7 +11,6 @@ WARNING_COUNT=`python test/pep8.py --filename '*.py,*.py.in' --ignore E . | wc -
 if test $ERROR_COUNT -gt $ERROR_LIMIT
 then
         echo "Error count $ERROR_COUNT is greater than limit $ERROR_LIMIT"
-        python test/pep8.py --filename '*.py,*.py.in' --ignore W .
         RESULT=1
 fi
 

--- a/test/travis-build
+++ b/test/travis-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Limits as of February 14, 2017
-ERROR_LIMIT=2844
+# Limits as of February 22, 2017
+ERROR_LIMIT=2781
 WARNING_LIMIT=46
 
 RESULT=0

--- a/test/travis-build
+++ b/test/travis-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Limits as of February 2, 2017
-ERROR_LIMIT=2847
+# Limits as of February 14, 2017
+ERROR_LIMIT=2844
 WARNING_LIMIT=46
 
 RESULT=0

--- a/test/travis-build
+++ b/test/travis-build
@@ -11,6 +11,7 @@ WARNING_COUNT=`python test/pep8.py --filename '*.py,*.py.in' --ignore E . | wc -
 if test $ERROR_COUNT -gt $ERROR_LIMIT
 then
         echo "Error count $ERROR_COUNT is greater than limit $ERROR_LIMIT"
+        python test/pep8.py --filename '*.py,*.py.in' --ignore W .
         RESULT=1
 fi
 

--- a/tools/MA_constants.py
+++ b/tools/MA_constants.py
@@ -194,3 +194,8 @@ updatable_key_fields = ["KEY_DESCRIPTION", "_GENI_KEY_FILENAME"]
 
 USER_CRED_LIFE_YEARS = 1 # See MA.get_user_credential
 # FIXME: username regex
+
+SWAP_NONCE = 'ncsa_nonce'
+SWAP_NONCE_TS = 'ncsa_nonce_ts'
+MEMBER_URN = 'MEMBER_URN'
+MEMBER_EPPN = '_GENI_MEMBER_EPPN'

--- a/tools/MA_constants.py
+++ b/tools/MA_constants.py
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------
-# Copyright (c) 2011-2016 Raytheon BBN Technologies
+# Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -197,5 +197,7 @@ USER_CRED_LIFE_YEARS = 1 # See MA.get_user_credential
 
 SWAP_NONCE = 'ncsa_nonce'
 SWAP_NONCE_TS = 'ncsa_nonce_ts'
+SWAP_DONE_TS = 'ncsa_swapped'
 MEMBER_URN = 'MEMBER_URN'
 MEMBER_EPPN = '_GENI_MEMBER_EPPN'
+MEMBER_EMAIL = 'MEMBER_EMAIL'

--- a/tools/MA_constants.py
+++ b/tools/MA_constants.py
@@ -195,7 +195,6 @@ updatable_key_fields = ["KEY_DESCRIPTION", "_GENI_KEY_FILENAME"]
 USER_CRED_LIFE_YEARS = 1  # See MA.get_user_credential
 # FIXME: username regex
 
-SWAP_ID_ATTR = 'gpo_swap_id'
 SWAP_TS_ATTR = 'gpo_swap_ts'
 SWAP_FROM_ATTR = 'gpo_swap_from'
 MEMBER_URN = 'MEMBER_URN'

--- a/tools/MA_constants.py
+++ b/tools/MA_constants.py
@@ -1,4 +1,4 @@
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -19,7 +19,7 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 credential_types = [
     {"type" : "geni_sfa", "version" : "3"},
@@ -192,12 +192,12 @@ allowed_create_key_fields = [
 ]
 updatable_key_fields = ["KEY_DESCRIPTION", "_GENI_KEY_FILENAME"]
 
-USER_CRED_LIFE_YEARS = 1 # See MA.get_user_credential
+USER_CRED_LIFE_YEARS = 1  # See MA.get_user_credential
 # FIXME: username regex
 
-SWAP_NONCE = 'ncsa_nonce'
-SWAP_NONCE_TS = 'ncsa_nonce_ts'
-SWAP_DONE_TS = 'ncsa_swapped'
+SWAP_ID_ATTR = 'gpo_swap_id'
+SWAP_TS_ATTR = 'gpo_swap_ts'
+SWAP_FROM_ATTR = 'gpo_swap_from'
 MEMBER_URN = 'MEMBER_URN'
 MEMBER_EPPN = '_GENI_MEMBER_EPPN'
 MEMBER_EMAIL = 'MEMBER_EMAIL'

--- a/tools/chapi_utils.py.in
+++ b/tools/chapi_utils.py.in
@@ -28,6 +28,8 @@ from email.mime.text import MIMEText
 from email.header import Header
 import os.path
 import datetime
+import string
+import random
 from chapi_log import *
 
 
@@ -120,3 +122,10 @@ def get_implementation_info(log_prefix):
         "code_release_date": str(code_timestamp),
         "site_update_date": str(code_timestamp)
     }
+
+def random_id(length=6):
+    chars = string.digits + string.uppercase
+    result = '';
+    for i in range(length):
+        result += chars[random.randint(0, 35)]
+    return result

--- a/tools/chapi_utils.py.in
+++ b/tools/chapi_utils.py.in
@@ -123,9 +123,10 @@ def get_implementation_info(log_prefix):
         "site_update_date": str(code_timestamp)
     }
 
+
 def random_id(length=6):
     chars = string.digits + string.uppercase
-    result = '';
+    result = ''
     for i in range(length):
         result += chars[random.randint(0, 35)]
     return result

--- a/tools/chapi_utils.py.in
+++ b/tools/chapi_utils.py.in
@@ -28,8 +28,6 @@ from email.mime.text import MIMEText
 from email.header import Header
 import os.path
 import datetime
-import string
-import random
 from chapi_log import *
 
 
@@ -122,11 +120,3 @@ def get_implementation_info(log_prefix):
         "code_release_date": str(code_timestamp),
         "site_update_date": str(code_timestamp)
     }
-
-
-def random_id(length=6):
-    chars = string.digits + string.uppercase
-    result = ''
-    for i in range(length):
-        result += chars[random.randint(0, 35)]
-    return result

--- a/tools/client.py
+++ b/tools/client.py
@@ -87,6 +87,8 @@ def parseOptions(args):
                       default=None)
     parser.add_option("--uuid3_arg", help="third UUID argument for some calls",
                       default=None)
+    parser.add_option("--urn2_arg", help="second URN argument for some calls",
+                      default=None)
     parser.add_option("--file_arg", help="FILE argument for some calls",
                       default=None)
     parser.add_option("--options", help="JSON of options argument",
@@ -422,11 +424,11 @@ def main(args=sys.argv, do_print=True):
                     member_eppn, project_id, slice_id)
 
     # MA Swap nonce method
-    elif opts.method in ['set_swap_nonce', 'swap_identities']:
+    elif opts.method in ['swap_identities']:
         options = {}
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.urn,
-                    opts.string_arg, opts.credentials, options)
+                    opts.urn2_arg, opts.credentials, options)
 
     # Methods that take attributes and options
     elif client_attributes:

--- a/tools/client.py
+++ b/tools/client.py
@@ -421,6 +421,13 @@ def main(args=sys.argv, do_print=True):
             _do_ssl(framework, suppress_errors, reason, fcn,
                     member_eppn, project_id, slice_id)
 
+    # MA Swap nonce method
+    elif opts.method in ['set_swap_nonce']:
+        options = {}
+        (result, msg) = \
+            _do_ssl(framework, suppress_errors, reason, fcn, opts.urn,
+                    opts.string_arg, opts.credentials, options)
+
     # Methods that take attributes and options
     elif client_attributes:
         (result, msg) = _do_ssl(framework, suppress_errors, reason, fcn,

--- a/tools/client.py
+++ b/tools/client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # ----------------------------------------------------------------------
-# Copyright (c) 2013-2016 Raytheon BBN Technologies
+# Copyright (c) 2013-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -422,7 +422,7 @@ def main(args=sys.argv, do_print=True):
                     member_eppn, project_id, slice_id)
 
     # MA Swap nonce method
-    elif opts.method in ['set_swap_nonce']:
+    elif opts.method in ['set_swap_nonce', 'swap_identities']:
         options = {}
         (result, msg) = \
             _do_ssl(framework, suppress_errors, reason, fcn, opts.urn,


### PR DESCRIPTION
Add MA.swap_identities to support swapping two user identities. Only the eppn and email address are actually swapped. All project and slice memberships are effectively swapped as a result of the eppn swap.

Fixes #557 
