### PR TITLE
Add geni-maintenance script for maintenance mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Fix authorization for get_requests_for_context
   ([#536](https://github.com/GENI-NSF/geni-ch/issues/536))
+* Add geni-maintenance script to set and clear maintenance mode
+  ([#552](https://github.com/GENI-NSF/geni-ch/issues/552))
 * Add support for swapping identities to support IdP changes
   ([#557](https://github.com/GENI-NSF/geni-ch/issues/557))
 

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -26,6 +26,7 @@ TEMPLATES = \
 	geni-install-templates \
 	geni-list-idp-members \
 	geni-list-pending-requests \
+	geni-maintenance \
 	geni-sign-tool-csr \
 	geni-expiring-certs
 
@@ -51,6 +52,7 @@ sbin_SCRIPTS = \
 	geni-install-templates \
 	geni-list-idp-members \
 	geni-list-pending-requests \
+	geni-maintenance \
 	geni-sign-tool-csr \
 	geni-expiring-certs
 

--- a/bin/geni-maintenance.in
+++ b/bin/geni-maintenance.in
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Copyright (c) 2017 Raytheon BBN Technologies
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and/or hardware specification (the "Work") to
+# deal in the Work without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Work, and to permit persons to whom the Work
+# is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Work.
+#
+# THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+# IN THE WORK.
+# ----------------------------------------------------------------------
+
+import argparse
+import os
+import sys
+import ConfigParser
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description='Set/Clear maintenance mode')
+
+    default_conf = '@pkgsysconfdir@/chapi.ini'
+    parser.add_argument("-c", "--conf", default=default_conf,
+                        help='chapi config file (default:%s)' % (default_conf))
+    parser.add_argument('--clear', action="store_true", default=False,
+                        help='clear maintenance mode')
+    parser.add_argument('message', nargs='?', default=None,
+                        help='the maintenance message')
+    args = parser.parse_args()
+    return args
+
+
+def load_ini(ini_file):
+    config = ConfigParser.SafeConfigParser()
+    config.read(ini_file)
+    return config
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+    args = parse_args(argv)
+    if not args.clear and not args.message:
+        print 'You must specify a message or use the --clear option'
+        return 2
+    config = load_ini(args.conf)
+    maint_file = config.get('geni', 'maintenance_outage_location')
+    print 'Found maintenance file %s' % (maint_file)
+    if args.clear:
+        # Delete the file
+        os.remove(maint_file)
+        print 'Cleared maintenance mode'
+    else:
+        # Write/create the file with message as the contents
+        with open(maint_file, 'wb') as dest:
+            dest.write(args.message)
+        print 'Set maintenance mode to %r' % (args.message)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/geni-chapi.spec
+++ b/geni-chapi.spec
@@ -84,6 +84,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_sbindir}/geni-list-idp-members
 %{_sbindir}/geni-list-member-projects
 %{_sbindir}/geni-list-pending-requests
+%{_sbindir}/geni-maintenance
 %{_sbindir}/geni-revoke-member-certificate
 %{_sbindir}/geni-revoke-member-privilege
 %{_sbindir}/geni-sign-tool-csr
@@ -565,6 +566,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man1/geni-list-idp-members.1.gz
 %{_mandir}/man1/geni-list-member-projects.1.gz
 %{_mandir}/man1/geni-list-pending-requests.1.gz
+%{_mandir}/man1/geni-maintenance.1.gz
 %{_mandir}/man1/geni-revoke-member-certificate.1.gz
 %{_mandir}/man1/geni-revoke-member-privilege.1.gz
 %{_mandir}/man1/geni-sign-tool-csr.1.gz

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,7 +1,16 @@
-edit = sed \
-	-e 's|@pkgdatadir[@]|$(pkgdatadir)|g'
+pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
 
-geni-check-errors.1: Makefile
+edit = sed \
+	-e 's|@pkgdatadir[@]|$(pkgdatadir)|g' \
+	-e 's|@pkgsysconfdir[@]|$(pkgsysconfdir)|g'
+
+TEMPLATES = \
+	geni-check-errors.1 \
+	geni-maintenance.1
+
+TEMPLATES.IN = $(TEMPLATES:%=%.in)
+
+$(TEMPLATES): Makefile
 	rm -f $@ $@.tmp
 	srcdir=''; \
 	  test -f ./$@.in || srcdir=$(srcdir)/; \
@@ -9,17 +18,16 @@ geni-check-errors.1: Makefile
 	chmod a-w $@.tmp
 	mv $@.tmp $@
 
-geni-check-errors.1: $(srcdir)/geni-check-errors.1.in
+%: $(srcdir)/%.in
 
 # Distribute but do not install
-EXTRA_DIST = \
-	geni-check-errors.1.in
+EXTRA_DIST = $(TEMPLATES.IN)
 
-CLEANFILES = \
-	geni-check-errors.1
+CLEANFILES = $(TEMPLATES)
 
 man_MANS = \
-	geni-check-errors.1
+	geni-check-errors.1 \
+	geni-maintenance.1
 
 dist_man_MANS = \
 	geni-add-member-privilege.1 \

--- a/man/geni-maintenance.1.in
+++ b/man/geni-maintenance.1.in
@@ -1,0 +1,41 @@
+.TH GENI-MAINTENANCE 1 "March 1, 2017"
+.SH NAME
+geni-maintenance \- set or clear maintenance mode
+.SH SYNOPSIS
+.B geni-maintenance
+.I <message>
+.br
+.B geni-maintenance
+.I \-\-clear
+.SH DESCRIPTION
+.B geni-maintenance
+allows a GENI operator to set or clear a maintenance outage.
+
+The first form enables maintenance mode and sets the maintenance message
+to the message argument. Use a quoted string for multiple words. See EXAMPLES
+for an example.
+
+The second form clears maintenance mode.
+.SH OPTIONS
+These programs follow the usual GNU command line syntax, with long
+options starting with two dashes (`-').
+.TP
+.B \-\-clear
+Clear the maintenance message. The message is ignored if the \-\-clear
+option is present.
+.TP
+.B \-c <conf file>, \-\-conf <conf file>
+The clearinghouse config file. This defaults to @pkgsysconfdir@/chapi.ini
+.TP
+.B \-h, \-\-help
+Show summary of options.
+.SH EXAMPLES
+Set maintenance outage:
+
+    geni-maintenance 'The GENI Clearinghouse is in maintenance'
+
+Clear maintenance outage:
+
+    geni-maintenance --clear
+.SH AUTHOR
+geni-maintenance was written by Raytheon BBN Technologies.


### PR DESCRIPTION
Add a script for operators to set and clear maintenance mode. Read the maintenance file location from the config file typically located in /etc. Allow an operator to set a maintenance message (is this used?) and to clear the maintenance mode.

Fixes #552 
