### PR TITLE
Use Ubuntu Trusty for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+# Force use of trusty until it is the default build
+# platform in late 2017
 dist: trusty
 virtualenv:
   system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 virtualenv:
   system_site_packages: true
 sudo: required
@@ -16,5 +17,3 @@ script:
   - test/travis-build
   - python -m unittest discover test
   - test/ch_server_tests.sh
-
-


### PR DESCRIPTION
Travis is [moving away from Ubuntu Precise](https://blog.travis-ci.com/2017-04-17-precise-EOL) because it is EOL. Travis will be moving to Ubuntu Trusty (14.04) as the default platform later in 2017. The geni-ch build works under trusty, so embrace the change by forcing the use of trusty for geni-ch builds.