### PR TITLE
Fix spelling of EXPIRED

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Consistently use PROJECT_EXPIRED and SLICE_EXPIRED
+  ([#537](https://github.com/GENI-NSF/geni-ch/issues/537))
 
 ## Installation Notes
 

--- a/plugins/sarm/SAv1PersistentImplementation.py
+++ b/plugins/sarm/SAv1PersistentImplementation.py
@@ -342,10 +342,14 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                                       SA.slice_field_mapping,
                                       "slice_urn", "slice_id",
                                       options, session)
-        slices = [{"SLICE_ROLE" : row.name, \
-                       "SLICE_UID" : row.slice_id, \
-                       "SLICE_URN": row.slice_urn, \
-                      "EXPIRED": row.expired } \
+        slices = [{"SLICE_ROLE": row.name,
+                   "SLICE_UID": row.slice_id,
+                   "SLICE_URN": row.slice_urn,
+                   "SLICE_EXPIRED": row.expired,
+                   # FIXME: 14-Jun-2017 "EXPIRED" is for backward compatibility
+                   # with omni until a new version of omni is released that
+                   # handles "SLICE_EXPIRED".
+                   "EXPIRED": row.expired}
                   for row in rows]
 
         result = self._successReturn(slices)
@@ -1032,10 +1036,14 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                                       SA.project_field_mapping,
                                       "project_name", "project_id",
                                       options, session)
-        projects = [{"PROJECT_ROLE" : row.name,
-                     "PROJECT_UID" : row.project_id,
+        projects = [{"PROJECT_ROLE": row.name,
+                     "PROJECT_UID": row.project_id,
                      "PROJECT_URN": row_to_project_urn(self.authority, row),
-                     "EXPIRED" : row.expired }
+                     "PROJECT_EXPIRED": row.expired,
+                     # FIXME: 14-Jun-2017 "EXPIRED" is for backward
+                     # compatibility with omni until a new version of omni
+                     # is released that handles "PROJECT_EXPIRED".
+                     "EXPIRED": row.expired}
                     for row in rows]
         result = self._successReturn(projects)
 
@@ -1332,10 +1340,14 @@ class SAv1PersistentImplementation(SAv1DelegateBase):
                                       SA.project_field_mapping,
                                       "project_name", "project_id",
                                       {}, session)
-        projects = [{"PROJECT_ROLE" : row.name,
-                     "PROJECT_UID" : row.project_id,
+        projects = [{"PROJECT_ROLE": row.name,
+                     "PROJECT_UID": row.project_id,
                      "PROJECT_URN": row_to_project_urn(self.authority, row),
-                     "EXPIRED" : row.expired }
+                     "PROJECT_EXPIRED": row.expired,
+                     # FIXME: 14-Jun-2017 "EXPIRED" is for backward
+                     # compatibility with omni until a new version of omni
+                     # is released that handles "PROJECT_EXPIRED".
+                     "EXPIRED": row.expired}
                     for row in rows]
         role = None
         for proj in projects:

--- a/test/travis-build
+++ b/test/travis-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Limits as of February 22, 2017
-ERROR_LIMIT=2798
+# Limits as of June 14, 2017
+ERROR_LIMIT=2778
 WARNING_LIMIT=46
 
 RESULT=0

--- a/test/travis-build
+++ b/test/travis-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Limits as of June 14, 2017
-ERROR_LIMIT=2778
+ERROR_LIMIT=2776
 WARNING_LIMIT=46
 
 RESULT=0

--- a/tools/chapi_utils.py.in
+++ b/tools/chapi_utils.py.in
@@ -88,12 +88,11 @@ def get_code_tag(log_prefix):
     try:
         with open(CHAPI_CODE_TAG_FILE, 'r') as f:
             code_tag = f.readline().strip()
-    except:
+    except IOError:
         msg = 'Cannot read code tag file %r.'
         msg = msg % (CHAPI_CODE_TAG_FILE)
         chapi_error(log_prefix, msg)
         code_tag = 'unknown'
-
     return code_tag
 
 
@@ -106,6 +105,7 @@ def get_code_timestamp(log_prefix):
         chapi_error(log_prefix,
                     "Can't find code tag file %s" % CHAPI_CODE_TAG_FILE)
     return code_timestamp
+
 
 CHAPI_CODE_TAG_FILE = "@pkgsysconfdir@/geni-ch-version.txt"
 CHAPI_CODE_URL = "https://github.com/GENI-NSF/geni-ch"


### PR DESCRIPTION
Some functions are returning EXPIRED instead of either PROJECT_EXPIRED
or SLICE_EXPIRED. Consistently use the prefixed versions to align
with the other fields which all have prefixes. Keep EXPIRED for
backward compatibility until omni is updated to look for the prefixed
versions of the keywords.

Fixes #537 