### PR TITLE
Fix spelling of EXPIRED

### DIFF
--- a/bin/geni-list-member-projects
+++ b/bin/geni-list-member-projects
@@ -122,7 +122,7 @@ def main(argv=None):
             raise Exception("Could not disable user %s" % (options.member))
     projects = result['value']
     for project in projects:
-        project_expired = project['EXPIRED']
+        project_expired = project['PROJECT_EXPIRED']
         if project_expired and not options.expired:
             continue
         project_urn = project['PROJECT_URN']

--- a/bin/geni-list-member-projects
+++ b/bin/geni-list-member-projects
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- Mode: python -*-
 #
-#----------------------------------------------------------------------
-# Copyright (c) 2013-2016 Raytheon BBN Technologies
+# ----------------------------------------------------------------------
+# Copyright (c) 2013-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -22,20 +22,22 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 #
-# Disable the given user so they can do no operations
+# Lists a user's projects.
 #
-# Communicates with a GENI Member Authority via its public API
+# Communicates with a GENI Member Authority and a GENI Slice Authority
+# via their public APIs
 #
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 import sys
 import optparse
 from urlparse import urlparse
 from chapiclient import chapi
+
 
 def parse_args(argv):
     parser = optparse.OptionParser(usage="List projects for the given user")
@@ -44,25 +46,27 @@ def parse_args(argv):
     parser.add_option("-c", "--certfile", metavar="FILE",
                       help="Invoker's GENI certificate")
     parser.add_option("-u", "--url",
-                             help="base authority URL (https://chSOMETHING)")
+                      help="base authority URL (https://chSOMETHING)")
     parser.add_option("-m", "--member", help="member id (a UUID or username)")
     parser.add_option("-e", "--expired", action="store_true", default=False,
                       help="Show expired projects")
-    options,args = parser.parse_args()
+    options, args = parser.parse_args()
     if not (options.keyfile and options.certfile and options.url
             and options.member):
         parser.print_usage()
         raise Exception("Missing some required arguments")
-    return options,args
+    return options, args
+
 
 def verify_url(url):
     parsed = urlparse(url)
     if (parsed.scheme in ('http', 'https')
-        and parsed.netloc
-        and parsed.path):
+            and parsed.netloc
+            and parsed.path):
         return parsed.geturl()
     else:
         raise Exception("Invalid url %r" % (url))
+
 
 def load_cert(certfile):
     f = open(certfile)
@@ -72,6 +76,7 @@ def load_cert(certfile):
     # Or will that be taken care of downstream, by the ch_interface?
     return cert
 
+
 def load_private_key(certfile):
     f = open(certfile)
     key = f.read()
@@ -80,6 +85,7 @@ def load_private_key(certfile):
     # Or will that be taken care of downstream, by the ch_interface?
     return key
 
+
 def project_name_from_urn(urn):
     plus_pos = urn.rfind('+')
     if plus_pos == -1:
@@ -87,11 +93,12 @@ def project_name_from_urn(urn):
     else:
         return urn[plus_pos+1:]
 
+
 def main(argv=None):
     if argv is None:
         argv = sys.argv
     try:
-        options,args = parse_args(argv)
+        options, args = parse_args(argv)
         ma_url = verify_url(chapi.service_url(options.url, 'MA'))
         sa_url = verify_url(chapi.service_url(options.url, 'SA'))
         cert = load_cert(options.certfile)
@@ -110,16 +117,17 @@ def main(argv=None):
     opts = dict()
     result = proxy.lookup_projects_for_member(member_urn, credentials, opts)
 
-    if not 'code' in result:
+    if 'code' not in result:
         raise Exception("Could not list projects for user %s. Result: %s" %
                         (options.member, result))
     status = result['code']
     if not status == 0:
-        if result.has_key('output'):
+        if 'output' in result:
             raise Exception("Could not list projects for user %s. Error %d: %s"
                             % (options.member, status, result['output']))
         else:
-            raise Exception("Could not disable user %s" % (options.member))
+            raise Exception("Could not list projects for user %s" %
+                            (options.member))
     projects = result['value']
     for project in projects:
         project_expired = project['PROJECT_EXPIRED']
@@ -133,6 +141,7 @@ def main(argv=None):
             annotation = ' (expired)'
         print '%s\t%s%s' % (project_role, project_name, annotation)
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/test/travis-build
+++ b/test/travis-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Limits as of June 14, 2017
-ERROR_LIMIT=2776
+# Limits as of June 15, 2017
+ERROR_LIMIT=2707
 WARNING_LIMIT=46
 
 RESULT=0

--- a/tools/portal_client.py
+++ b/tools/portal_client.py
@@ -1,5 +1,5 @@
-#----------------------------------------------------------------------
-# Copyright (c) 2011-2016 Raytheon BBN Technologies
+# ----------------------------------------------------------------------
+# Copyright (c) 2011-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -19,7 +19,7 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 from gcf.omnilib.util.dossl import _do_ssl
 import xmlrpclib
@@ -27,6 +27,7 @@ from gcf.omnilib.frameworks.framework_base import Framework_Base
 
 # Emulate CHAPI traffic supporting specific portal pages:
 # e.g. home, projects, slices
+
 
 class MAClientFramework(Framework_Base):
     def __init__(self, config, opts):
@@ -36,26 +37,31 @@ class MAClientFramework(Framework_Base):
         self.fwtype = "MA Ciient"
         self.opts = opts
 
-def emulate_portal_page(opts, verbose = False):
+
+def emulate_portal_page(opts, verbose=False):
 
     suppress_errors = None
     reason = "Testing"
-    config = {'cert' : opts.cert, 'key' : opts.key}
+    config = {'cert': opts.cert, 'key': opts.key}
 
     framework = MAClientFramework(config, {})
     ma_url = opts.url
     sa_url = opts.url.replace('/MA', '/SA')
     cs_url = opts.url.replace('/MA', '/CS')
     log_url = opts.url.replace('/MA', '/LOG')
-    ma_client = framework.make_client(ma_url, opts.key, opts.cert, verbose=False)
-    sa_client = framework.make_client(sa_url, opts.key, opts.cert, verbose=False)
-    cs_client = framework.make_client(cs_url, opts.key, opts.cert, verbose=False)
-    log_client = framework.make_client(log_url, opts.key, opts.cert, verbose=False)
+    ma_client = framework.make_client(ma_url, opts.key, opts.cert,
+                                      verbose=False)
+    sa_client = framework.make_client(sa_url, opts.key, opts.cert,
+                                      verbose=False)
+    cs_client = framework.make_client(cs_url, opts.key, opts.cert,
+                                      verbose=False)
+    log_client = framework.make_client(log_url, opts.key, opts.cert,
+                                       verbose=False)
 
     if opts.page == "home":
         print "Fetching home page for %s" % opts.eppn
         # Lookup public member info by EPPN
-        client_options = {'match' : {'_GENI_MEMBER_EPPN' : opts.eppn}}
+        client_options = {'match': {'_GENI_MEMBER_EPPN': opts.eppn}}
         (public_info, msg) = _do_ssl(framework, suppress_errors, reason,
                                      ma_client.lookup_public_member_info,
                                      opts.credentials, client_options)
@@ -63,14 +69,14 @@ def emulate_portal_page(opts, verbose = False):
         member_uid = public_info['value'][member_urn]['MEMBER_UID']
 
         # Lookup identifying info by UID
-        client_options = {'match' : {'MEMBER_UID': [member_uid]}}
+        client_options = {'match': {'MEMBER_UID': [member_uid]}}
         (identifying_info, msg) = _do_ssl(framework, suppress_errors, reason,
                                           ma_client.lookup_identifying_member_info,
                                           opts.credentials, client_options)
 
         # Lookup private key by UID
-        client_options = {'match' : {'MEMBER_UID': [member_uid]},
-                          'filter' : ['_GENI_MEMBER_INSIDE_PRIVATE_KEY']}
+        client_options = {'match': {'MEMBER_UID': [member_uid]},
+                          'filter': ['_GENI_MEMBER_INSIDE_PRIVATE_KEY']}
         (private_info, msg) = _do_ssl(framework, suppress_errors, reason,
                                       ma_client.lookup_private_member_info,
                                       opts.credentials, client_options)
@@ -80,25 +86,25 @@ def emulate_portal_page(opts, verbose = False):
             print "Result = %s " % private_info
 
         # Lookup public inside cert by UID
-        client_options = {'match' : {'MEMBER_UID' : [member_uid]},
-                          'filter' : ['_GENI_MEMBER_INSIDE_CERTIFICATE']}
+        client_options = {'match': {'MEMBER_UID': [member_uid]},
+                          'filter': ['_GENI_MEMBER_INSIDE_CERTIFICATE']}
         (public_info, msg) = _do_ssl(framework, suppress_errors, reason,
-                                      ma_client.lookup_public_member_info,
-                                      opts.credentials, client_options)
+                                     ma_client.lookup_public_member_info,
+                                     opts.credentials, client_options)
         if verbose:
             print "Result = %s " % public_info
 
         # get_permissions
-        client_options = {'_dummy' : ''}
+        client_options = {'_dummy': ''}
         (permissions, msg) = _do_ssl(framework, suppress_errors, reason,
-                                      cs_client.get_permissions,
+                                     cs_client.get_permissions,
                                      member_uid,
-                                      opts.credentials, client_options)
+                                     opts.credentials, client_options)
         if verbose:
             print "Result = %s " % permissions
 
         # Lookup projects for member
-        client_options = {'_dummy' : ''}
+        client_options = {'_dummy': ''}
         (projects_info, msg) = _do_ssl(framework, suppress_errors, reason,
                                        sa_client.lookup_projects_for_member,
                                        member_urn,
@@ -107,57 +113,60 @@ def emulate_portal_page(opts, verbose = False):
             print "Result = %s " % projects_info
 
         # Lookup projects
-        project_uids = [project_info['PROJECT_UID'] \
-                            for project_info in projects_info['value']
+        project_uids = [project_info['PROJECT_UID']
+                        for project_info in projects_info['value']
                         if not project_info['PROJECT_EXPIRED']]
-        client_options = {'match' : {'PROJECT_UID' : project_uids}}
+        client_options = {'match': {'PROJECT_UID': project_uids}}
         (projects, msg) = _do_ssl(framework, suppress_errors, reason,
-                                       sa_client.lookup_projects,
-                                       opts.credentials, client_options)
+                                  sa_client.lookup_projects,
+                                  opts.credentials, client_options)
         if verbose:
             print "Result = %s" % projects
 
         # Lookup slices for member
-        client_options = {'_dummy' : ''}
+        client_options = {'_dummy': ''}
         (slices_info, msg) = _do_ssl(framework, suppress_errors, reason,
-                                       sa_client.lookup_slices_for_member,
-                                       member_urn,
-                                       opts.credentials, client_options)
+                                     sa_client.lookup_slices_for_member,
+                                     member_urn,
+                                     opts.credentials, client_options)
         if verbose:
             print "Result = %s " % slices_info
 
         # Lookup slices
-        slice_uids = [slice_info['SLICE_UID'] \
-                            for slice_info in slices_info['value']
+        slice_uids = [slice_info['SLICE_UID']
+                      for slice_info in slices_info['value']
                       if not slice_info['SLICE_EXPIRED']]
-        client_options = {'match' : {'SLICE_UID' : slice_uids}}
+        client_options = {'match': {'SLICE_UID': slice_uids}}
         (slices, msg) = _do_ssl(framework, suppress_errors, reason,
-                                       sa_client.lookup_slices,
-                                       opts.credentials, client_options)
+                                sa_client.lookup_slices,
+                                opts.credentials, client_options)
         if verbose:
             print "Result = %s " % slices
 
         # Lookup public member info for all project leads, slice_owners
         member_uids = []
         for slice_urn, slice_data in slices['value'].items():
-            if slice_data['SLICE_EXPIRED']: continue
+            if slice_data['SLICE_EXPIRED']:
+                continue
             slice_owner_uid = slice_data['_GENI_SLICE_OWNER']
             if slice_owner_uid not in member_uids:
                 member_uids.append(slice_owner_uid)
         for project_urn, project_data in projects['value'].items():
-            if project_data['PROJECT_EXPIRED']: continue
+            if project_data['PROJECT_EXPIRED']:
+                continue
             project_lead_uid = project_data['_GENI_PROJECT_OWNER']
             if project_lead_uid not in member_uids:
                 member_uids.append(project_lead_uid)
-        client_options = {'match' : {'MEMBER_UID' : member_uids}}
-        (members_public_info, msg) = _do_ssl(framework, suppress_errors, reason,
-                                       ma_client.lookup_public_member_info,
-                                       opts.credentials, client_options)
+        client_options = {'match': {'MEMBER_UID': member_uids}}
+        (members_public_info, msg) = _do_ssl(framework, suppress_errors,
+                                             reason,
+                                             ma_client.lookup_public_member_info,
+                                             opts.credentials, client_options)
         if verbose:
             print "Result = %s " % members_public_info
 
         # Lookup identifying member info for all project leads, slice_owners
-        client_options = {'match' : {'MEMBER_UID' : member_uids}}
+        client_options = {'match': {'MEMBER_UID': member_uids}}
         (members_identifying_info, msg) = _do_ssl(framework,
                                                   suppress_errors, reason,
                                                   ma_client.lookup_identifying_member_info,
@@ -166,7 +175,7 @@ def emulate_portal_page(opts, verbose = False):
             print "Result = %s " % members_identifying_info
 
         # Lookup pending requests for user
-        client_options = {'_dummy' : ''}
+        client_options = {'_dummy': ''}
         (pending_requests, msg) = _do_ssl(framework, suppress_errors, reason,
                                           sa_client.get_pending_requests_for_user,
                                           member_uid, 1, '',
@@ -176,7 +185,7 @@ def emulate_portal_page(opts, verbose = False):
 
         # Lookup identifying member info for all project leads and slice owners
         # *** Looks like we're doing this twice...
-        client_options = {'match' : {'MEMBER_UID' : member_uids}}
+        client_options = {'match': {'MEMBER_UID': member_uids}}
         (members_identifying_info, msg) = _do_ssl(framework,
                                                   suppress_errors, reason,
                                                   ma_client.lookup_identifying_member_info,
@@ -185,12 +194,12 @@ def emulate_portal_page(opts, verbose = False):
             print "Result = %s " % members_identifying_info
 
         # Lookup requests by user
-        client_options = {'_dummy' : ''}
+        client_options = {'_dummy': ''}
         (pending_requests, msg) = _do_ssl(framework,
-                                         suppress_errors, reason,
-                                         sa_client.get_requests_by_user,
+                                          suppress_errors, reason,
+                                          sa_client.get_requests_by_user,
                                           member_uid, 1, '', 0,
-                                         opts.credentials, client_options)
+                                          opts.credentials, client_options)
         if verbose:
             print "Result = %s " % pending_requests
 
@@ -199,11 +208,11 @@ def emulate_portal_page(opts, verbose = False):
         for pending_request in pending_requests['value']:
             project_uid = pending_request['context_id']
             project_uids.append(project_uid)
-        client_options = {'match' : {'PROJECT_UID' : project_uids}}
+        client_options = {'match': {'PROJECT_UID': project_uids}}
         (pending_projects, msg) = _do_ssl(framework,
-                                         suppress_errors, reason,
-                                         sa_client.lookup_projects,
-                                         opts.credentials, client_options)
+                                          suppress_errors, reason,
+                                          sa_client.lookup_projects,
+                                          opts.credentials, client_options)
         if verbose:
             print "Result = %s " % pending_projects
 
@@ -211,12 +220,14 @@ def emulate_portal_page(opts, verbose = False):
         member_uids = []
         for pending_project_urn, pending_project_data in pending_projects['value'].items():
             lead_uid = pending_project_data['_GENI_PROJECT_OWNER']
-            if lead_uid not in member_uids: member_uids.append(lead_uid)
-        client_options = {'match' : {'MEMBER_UID' : member_uids}}
+            if lead_uid not in member_uids:
+                member_uids.append(lead_uid)
+        client_options = {'match': {'MEMBER_UID': member_uids}}
         (pending_project_leads, msg) = _do_ssl(framework,
-                                         suppress_errors, reason,
-                                         ma_client.lookup_identifying_member_info,
-                                         opts.credentials, client_options)
+                                               suppress_errors, reason,
+                                               ma_client.lookup_identifying_member_info,
+                                               opts.credentials,
+                                               client_options)
         if verbose:
             print "Result = %s " % pending_project_leads
 
@@ -224,7 +235,8 @@ def emulate_portal_page(opts, verbose = False):
         (log_entries, msg) = _do_ssl(framework,
                                      suppress_errors, reason,
                                      log_client.get_log_entries_for_context,
-                                     5, member_uid, 24, opts.credentials, client_options)
+                                     5, member_uid, 24, opts.credentials,
+                                     client_options)
 
         if verbose:
             print "Result = %s " % log_entries
@@ -233,11 +245,11 @@ def emulate_portal_page(opts, verbose = False):
         (log_entries, msg) = _do_ssl(framework,
                                      suppress_errors, reason,
                                      log_client.get_log_entries_by_author,
-                                     member_uid, 24, opts.credentials, client_options)
+                                     member_uid, 24, opts.credentials,
+                                     client_options)
 
         if verbose:
             print "Result = %s " % log_entries
-
 
         print "Done fetching home page for %s" % opts.eppn
 

--- a/tools/portal_client.py
+++ b/tools/portal_client.py
@@ -109,7 +109,7 @@ def emulate_portal_page(opts, verbose = False):
         # Lookup projects
         project_uids = [project_info['PROJECT_UID'] \
                             for project_info in projects_info['value']
-                        if not project_info['EXPIRED']]
+                        if not project_info['PROJECT_EXPIRED']]
         client_options = {'match' : {'PROJECT_UID' : project_uids}}
         (projects, msg) = _do_ssl(framework, suppress_errors, reason,
                                        sa_client.lookup_projects,
@@ -129,7 +129,7 @@ def emulate_portal_page(opts, verbose = False):
         # Lookup slices
         slice_uids = [slice_info['SLICE_UID'] \
                             for slice_info in slices_info['value']
-                      if not slice_info['EXPIRED']]
+                      if not slice_info['SLICE_EXPIRED']]
         client_options = {'match' : {'SLICE_UID' : slice_uids}}
         (slices, msg) = _do_ssl(framework, suppress_errors, reason,
                                        sa_client.lookup_slices,


### PR DESCRIPTION
Additional fixes for #537. A script and a test harness both used `EXPIRED`. Use the prefixed versions `SLICE_EXPIRED` and `PROJECT_EXPIRED` instead.

Fix PEP8/pycodestyle warnings in these files as well.