### PR TITLE
Temporarily fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 # Force use of trusty until it is the default build
 # platform in late 2017
 dist: trusty
+group: deprecated-2017Q2
 virtualenv:
   system_site_packages: true
 sudo: required


### PR DESCRIPTION
[Travis CI](https://travis-ci.org/) [updated their Ubuntu Trusty image](https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch) and that has broken the geni-ch build. The issue appears to be with the `virutalenv` `system_site_packages` setting. Travis support is looking into the issue.

As a temporary workaround, we'll use the older trusty image by adding a tag to the travis YAML file:

```
group: deprecated-2017Q2
```
