### PR TITLE
Fix import error in geni-sign-tool-csr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Fix import error in geni-sign-tool-csr
+  ([#577](https://github.com/GENI-NSF/geni-ch/issues/577))
 
 ## Installation Notes
 

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,13 +1,13 @@
 #----------------------------------------------------------------------
-# 'tooldir' and 'gcfdir' are here for substitution into scripts.
+# 'chapidir' and 'gcfdir' are here for substitution into scripts.
 #
-# TODO: keep 'tooldir' in sync with ../tools/Makefile.am (see note
-#       there)
+# TODO: keep 'chapidir' in sync with variables in ../tools/Makefile.am
+#       and ../plugins/Makefile.am (see notes there)
 #
 # TODO: add gcfdir to configure so it can be specified for all of
 #       chapi in one place, and even hunted for in known locations.
 #----------------------------------------------------------------------
-tooldir = $(pkgdatadir)/../geni-ch/chapi/chapi/tools
+chapidir = $(pkgdatadir)/../geni-ch/chapi/chapi
 gcfdir = $(pkgdatadir)/../geni-ch/gcf/src
 pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
 templatesdir = $(pkgdatadir)/templates
@@ -17,7 +17,7 @@ edit = sed \
 	-e 's|@pkgdatadir[@]|$(pkgdatadir)|g' \
 	-e 's|@pkgsysconfdir[@]|$(pkgsysconfdir)|g' \
 	-e 's|@prefix[@]|$(prefix)|g' \
-	-e 's|@tooldir[@]|$(tooldir)|g' \
+	-e 's|@chapidir[@]|$(chapidir)|g' \
 	-e 's|@gcfdir[@]|$(gcfdir)|g' \
 	-e 's|@templatesdir[@]|$(templatesdir)|g'
 

--- a/bin/geni-sign-tool-csr.in
+++ b/bin/geni-sign-tool-csr.in
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- Mode: python -*-
 
-#----------------------------------------------------------------------
-# Copyright (c) 2013-2016 Raytheon BBN Technologies
+# ----------------------------------------------------------------------
+# Copyright (c) 2013-2017 Raytheon BBN Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and/or hardware specification (the "Work") to
@@ -22,13 +22,13 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 # IN THE WORK.
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 #
 # Sign a CSR for a tool certificate.
 #
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 import sys
 import optparse
@@ -40,14 +40,15 @@ sys.path.insert(1, '@tooldir@')
 
 import cert_utils as cu
 
+
 def parse_args(argv):
     parser = optparse.OptionParser(usage="Sign a CSR for a GENI tool")
     parser.add_option("-k", "--keyfile", metavar="FILE",
                       help="Signing private key")
     parser.add_option("-c", "--certfile", metavar="FILE",
                       help="Signing certificate")
-    parser.add_option("-d", "--days", metavar="NUMBER", default=365, type='int',
-                      help="Validity period in days")
+    parser.add_option("-d", "--days", metavar="NUMBER", default=365,
+                      type='int', help="Validity period in days")
     parser.add_option("-e", "--email", metavar="TOOL_ADMIN_EMAIL",
                       help="Tool administrator email address")
     parser.add_option("-i", "--id",
@@ -61,12 +62,13 @@ def parse_args(argv):
     parser.add_option("--use-csr-subject",
                       action="store_true", default=False,
                       help="Use subject provided by CSR")
-    options,args = parser.parse_args()
+    options, args = parser.parse_args()
     if not (options.keyfile and options.certfile and options.email
             and options.id and options.authority and options.csr):
         parser.print_usage()
         raise Exception("Missing some required arguments")
-    return options,args
+    return options, args
+
 
 def load_signer_chain(pemfile):
     # Read the file line by line, loading everything between a begin
@@ -89,11 +91,12 @@ def load_signer_chain(pemfile):
             pemline = f.readline()
     return chain
 
+
 def main(argv=None):
     if argv is None:
         argv = sys.argv
     try:
-        options,args = parse_args(argv)
+        options, args = parse_args(argv)
     except Exception as e:
         sys.stderr.write(str(e) + '\n')
         return 1
@@ -132,6 +135,7 @@ def main(argv=None):
         # send cert to stdout
         print chain
     return 0
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/bin/geni-sign-tool-csr.in
+++ b/bin/geni-sign-tool-csr.in
@@ -36,9 +36,17 @@ import uuid
 
 # Add sfa include path after script directory but before system path
 sys.path.insert(1, '@gcfdir@')
-sys.path.insert(1, '@tooldir@')
+sys.path.insert(1, '@chapidir@')
 
-import cert_utils as cu
+# Wrap these in a try/finally block to appease pycodestyle
+try:
+    import tools.cert_utils as cu
+    import tools.pluginmanager as pm
+    import tools.chapi_log
+    import logging
+    from plugins.chapiv1rpc.chapi.Parameters import set_parameters
+finally:
+    pass
 
 
 def parse_args(argv):
@@ -113,6 +121,11 @@ def main(argv=None):
             return 1
 
     signer_chain = load_signer_chain(options.certfile)
+
+    # set up the environment for make_cert()
+    pm.registerService('config', pm.ConfigDB())
+    tools.chapi_log.chapi_logging_basic_config(level=logging.WARN)
+    set_parameters()
 
     # make_cert() prepends the 'URI:' part.
     tool_urn = 'urn:publicid:IDN+%s+tool+%s' % (options.authority, options.id)


### PR DESCRIPTION
Update script to build pluginmanager environment so that make_cert
can be called and find the right config file. Fix some python style
warnings as well.

Fixes #577 