### PR TITLE
Generate username when cannot be generated from IDP

### DIFF
--- a/plugins/marm/MAv1Implementation.py
+++ b/plugins/marm/MAv1Implementation.py
@@ -102,7 +102,7 @@ def derive_username(email_address, session):
         username = username[0:8]
 
     if not username:
-        username = "geni1"
+        username = "geni3"
 
     if not username_exists(username, session):
         # print "no conflict with $username<br/>\n";


### PR DESCRIPTION
GENI is unable to generate usernames for NCSA Users from (*@park.edu) . Thus username generation defaults to this code. Further down in other routines an index is added (0..99). Once the index hits 99 for the last username generated, this patch will have to be updated again.